### PR TITLE
Wrap returned element with next router context provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Next page tester will take care of:
 
 ## Options
 
-| Property           | Description                                                                        | type         | Default |
-| ------------------ | ---------------------------------------------------------------------------------- | ------------ | ------- |
-| **route**          | Next route (must start with `/`)                                                   | -            | -       |
-| **pagesDirectory** | Absolute path of Next's `/pages` folder                                            | -            | -       |
-| **req**            | Override default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res` | -       |
-| **res**            | Override default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req` | -       |
+| Property           | Description                                                                        | type               | Default |
+| ------------------ | ---------------------------------------------------------------------------------- | ------------------ | ------- |
+| **route**          | Next route (must start with `/`)                                                   | -                  | -       |
+| **pagesDirectory** | Absolute path of Next's `/pages` folder                                            | -                  | -       |
+| **req**            | Override default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -       |
+| **res**            | Override default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -       |
+| **router**         | Override default mocked Next router object                                         | `router => router` | -       |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Next page tester will take care of:
 
 ## Options
 
-| Property              | Description                                                                                | Default |
-| --------------------- | ------------------------------------------------------------------------------------------ | ------- |
-| **route**             | Next route (must start with `/`)                                                           | -       |
-| **pagesDirectory**    | Absolute path of Next's `/pages` folder                                                    | -       |
-| **req**               | Override default mocked [HTTP request object][req-docs] props (`getServerSideProps` only)  | -       |
-| **res**               | Override default mocked [HTTP response object][res-docs] props (`getServerSideProps` only) | -       |
+| Property           | Description                                                                        | type         | Default |
+| ------------------ | ---------------------------------------------------------------------------------- | ------------ | ------- |
+| **route**          | Next route (must start with `/`)                                                   | -            | -       |
+| **pagesDirectory** | Absolute path of Next's `/pages` folder                                            | -            | -       |
+| **req**            | Override default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res` | -       |
+| **res**            | Override default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req` | -       |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,18 @@ Next page tester will take care of:
 | **pagesDirectory** | Absolute path of Next's `/pages` folder                                            | -                  | -       |
 | **req**            | Override default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -       |
 | **res**            | Override default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -       |
-| **router**         | Override default mocked Next router object                                         | `router => router` | -       |
+| **router**         | Override default mocked [Next router object][next-docs-router]                     | `router => router` | -       |
 
 ## Notes
 
 `req` and `res` objects are mocked with [node-mocks-http][node-mocks-http].
 
+Next page tester can be used with any testing framework/library.
+
 ## Todo's
 
 - Make available dynamic api routes under `/pages/api`
 - Consider adding custom App and Document
-- Get `next/router` (especially `withRouter` and `useRouter`) to work
 - Switch to Typescript
 
 [ci]: https://travis-ci.com/toomuchdesign/next-page-tester
@@ -70,3 +71,4 @@ Next page tester will take care of:
 [node-mocks-http]: https://www.npmjs.com/package/node-mocks-http
 [next-docs-routing]: https://nextjs.org/docs/routing/introduction
 [next-docs-data-fetching]: https://nextjs.org/docs/basic-features/data-fetching
+[next-docs-router]: https://nextjs.org/docs/api-reference/next/router

--- a/package-lock.json
+++ b/package-lock.json
@@ -1289,6 +1289,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
@@ -1652,6 +1662,86 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@testing-library/dom": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.1.tgz",
+      "integrity": "sha512-TemHWY59gvzcScGiE5eooZpzYk9GaED0TuuK4WefbIc/DQg0L5wOpnj7MIEeAGF3B7Ekf1kvmVnQ97vwz4Lmhg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^26.4.2"
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "5.11.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.4.tgz",
+      "integrity": "sha512-6RRn3epuweBODDIv3dAlWjOEHQLpGJHB2i912VS3JQtsD22+ENInhdDNl4ZZQiViLlIfFinkSET/J736ytV9sw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.0.2.tgz",
+      "integrity": "sha512-iOuNNHt4ZgMH5trSKC4kaWDcKzUOf7e7KQIcu7xvGCd68/w1EegbW89F9T5sZ4IjS0gAXdvOfZbG9ESZ7YjOug==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@testing-library/dom": "^7.23.0"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.9",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
@@ -1732,6 +1822,86 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.13.tgz",
+      "integrity": "sha512-sCzjKow4z9LILc6DhBvn5AkIfmQzDZkgtVVKmGwVrs5tuid38ws281D4l+7x1kP487+FlKDh5kfMZ8WSPAdmdA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+          "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "*",
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
+      }
+    },
     "@types/node": {
       "version": "14.6.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
@@ -1761,6 +1931,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.2.tgz",
+      "integrity": "sha512-K7nUSpH/5i8i0NagTJ+uFUDRueDlnMNhJtMjMwTGPPSqyImbWC/hgKPDCKt6Phu2iMJg2kWqlax+Ucj2DKMwpA==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.5",
@@ -2170,6 +2349,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "arity-n": {
@@ -3240,6 +3429,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3673,6 +3868,12 @@
           "dev": true
         }
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
+      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "1.0.1",
@@ -5992,6 +6193,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -7223,6 +7430,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-dom": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7411,6 +7630,16 @@
       "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
       "requires": {
         "minimatch": "3.0.4"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regenerate": {
@@ -8143,6 +8372,16 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
     "schema-utils": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
@@ -8736,6 +8975,15 @@
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "style-loader": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@testing-library/jest-dom": "^5.11.4",
+    "@testing-library/react": "^11.0.2",
     "babel-jest": "^26.3.0",
     "coveralls": "^3.1.0",
     "husky": "^4.0.0",
@@ -36,7 +38,8 @@
     "lint-staged": "^10.0.0",
     "next": "^9.5.3",
     "prettier": "^2.0.0",
-    "react": "^16.13.1"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "dependencies": {
     "node-mocks-http": "^1.9.0",

--- a/src/__tests__/__fixtures__/pages/api/index.js
+++ b/src/__tests__/__fixtures__/pages/api/index.js
@@ -1,0 +1,3 @@
+export default function api_index(props) {
+  return `/api/index - props: ${JSON.stringify(props)}`;
+}

--- a/src/__tests__/__fixtures__/pages/blog/99.js
+++ b/src/__tests__/__fixtures__/pages/blog/99.js
@@ -1,3 +1,3 @@
 export default function blog_99(props) {
-  return `/blog/99 - props: ${props}`;
+  return `/blog/99 - props: ${JSON.stringify(props)}`;
 }

--- a/src/__tests__/__fixtures__/pages/blog/[id].js
+++ b/src/__tests__/__fixtures__/pages/blog/[id].js
@@ -1,3 +1,5 @@
-export default function blog_$id$(props) {
-  return `/blog/[id] - props: ${JSON.stringify(props)}`;
+import { useRouter } from 'next/router';
+export default function blog_$id$({ routerMock }) {
+  const { query } = routerMock || useRouter();
+  return `/blog/[id] - router query: ${JSON.stringify(query)}`;
 }

--- a/src/__tests__/__fixtures__/pages/blog/[id].js
+++ b/src/__tests__/__fixtures__/pages/blog/[id].js
@@ -1,3 +1,3 @@
 export default function blog_$id$(props) {
-  return `/blog/[id] - props: ${props}`;
+  return `/blog/[id] - props: ${JSON.stringify(props)}`;
 }

--- a/src/__tests__/__fixtures__/pages/blog/index.js
+++ b/src/__tests__/__fixtures__/pages/blog/index.js
@@ -1,3 +1,3 @@
 export default function blog_index(props) {
-  return `/blog/index - props: ${props}`;
+  return `/blog/index - props: ${JSON.stringify(props)}`;
 }

--- a/src/__tests__/__fixtures__/pages/catch-all/[id]/[...slug]/index.js
+++ b/src/__tests__/__fixtures__/pages/catch-all/[id]/[...slug]/index.js
@@ -1,15 +1,8 @@
-import { sleep } from '../../../../../../utils';
+import { useRouter } from 'next/router';
 
-export default function catchall_$id$_$slug$(props) {
-  return `/catch-all/[id]/[...slug]/index - props: ${JSON.stringify(props)}`;
-}
-
-export async function getServerSideProps({ params, query }) {
-  await sleep(1);
-  return {
-    props: {
-      params,
-      query,
-    },
-  };
+export default function catchall_$id$_$slug$({ routerMock }) {
+  const { query } = routerMock || useRouter();
+  return `/catch-all/[id]/[...slug]/index - router query: ${JSON.stringify(
+    query
+  )}`;
 }

--- a/src/__tests__/__fixtures__/pages/catch-all/[id]/[...slug]/index.js
+++ b/src/__tests__/__fixtures__/pages/catch-all/[id]/[...slug]/index.js
@@ -1,8 +1,7 @@
 import { sleep } from '../../../../../../utils';
 
 export default function catchall_$id$_$slug$(props) {
-  console.log(props);
-  return `/catch-all/[id]/[...slug]/index - props: ${props}`;
+  return `/catch-all/[id]/[...slug]/index - props: ${JSON.stringify(props)}`;
 }
 
 export async function getServerSideProps({ params, query }) {

--- a/src/__tests__/__fixtures__/pages/index.js
+++ b/src/__tests__/__fixtures__/pages/index.js
@@ -1,3 +1,3 @@
 export default function index(props) {
-  return `/index - props: ${props}`;
+  return `/index - props: ${JSON.stringify(props)}`;
 }

--- a/src/__tests__/__fixtures__/pages/optional-catch-all/[id]/[[...slug]]/index.js
+++ b/src/__tests__/__fixtures__/pages/optional-catch-all/[id]/[[...slug]]/index.js
@@ -1,17 +1,8 @@
-import { sleep } from '../../../../../../utils';
+import { useRouter } from 'next/router';
 
-export default function optionalcatchall_$id$_$slug$(props) {
-  return `/optional-catch-all/[id]/[...slug]/index - props: ${JSON.stringify(
-    props
+export default function optionalcatchall_$id$_$slug$({ routerMock }) {
+  const { query } = routerMock || useRouter();
+  return `/optional-catch-all/[id]/[...slug]/index - router query: ${JSON.stringify(
+    query
   )}`;
-}
-
-export async function getServerSideProps({ params, query }) {
-  await sleep(1);
-  return {
-    props: {
-      params,
-      query,
-    },
-  };
 }

--- a/src/__tests__/__fixtures__/pages/optional-catch-all/[id]/[[...slug]]/index.js
+++ b/src/__tests__/__fixtures__/pages/optional-catch-all/[id]/[[...slug]]/index.js
@@ -1,8 +1,9 @@
 import { sleep } from '../../../../../../utils';
 
 export default function optionalcatchall_$id$_$slug$(props) {
-  console.log(props);
-  return `/optional-catch-all/[id]/[...slug]/index - props: ${props}`;
+  return `/optional-catch-all/[id]/[...slug]/index - props: ${JSON.stringify(
+    props
+  )}`;
 }
 
 export async function getServerSideProps({ params, query }) {

--- a/src/__tests__/__fixtures__/pages/ssg/[id].js
+++ b/src/__tests__/__fixtures__/pages/ssg/[id].js
@@ -1,7 +1,7 @@
 import { sleep } from '../../../../utils';
 
 export default function ssg_$id$(props) {
-  return `/ssg/[id] - props: ${props}`;
+  return `/ssg/[id] - props: ${JSON.stringify(props)}`;
 }
 
 export async function getStaticProps({ params }) {

--- a/src/__tests__/__fixtures__/pages/ssr/[id].js
+++ b/src/__tests__/__fixtures__/pages/ssr/[id].js
@@ -1,7 +1,7 @@
 import { sleep } from '../../../../utils';
 
 export default function ssr_$id$(props) {
-  return `/ssr/[id] - props: ${props}`;
+  return `/ssr/[id] - props: ${JSON.stringify(props)}`;
 }
 
 export async function getServerSideProps(ctx) {

--- a/src/__tests__/__fixtures__/pages/with-router/[id].js
+++ b/src/__tests__/__fixtures__/pages/with-router/[id].js
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 
-export default function WithRouter() {
-  const router = useRouter();
-  const { id } = router.query;
-  return id;
+export default function WithRouter({ routerMock }) {
+  const router = routerMock || useRouter();
+  const { query, pathname, asPath, route } = router;
+  return `Router: ${JSON.stringify({ asPath, pathname, query, route })}`;
 }

--- a/src/__tests__/__fixtures__/pages/with-router/[id].js
+++ b/src/__tests__/__fixtures__/pages/with-router/[id].js
@@ -1,0 +1,7 @@
+import { useRouter } from 'next/router';
+
+export default function WithRouter() {
+  const router = useRouter();
+  const { id } = router.query;
+  return id;
+}

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -235,18 +235,18 @@ describe('getPage', () => {
     it('receives expected router object', async () => {
       const actualPage = await getPage({
         pagesDirectory,
-        route: '/with-router/99&foo=bar',
+        route: '/with-router/99?foo=bar#moo',
       });
 
       const { container: actual } = render(actualPage);
       const { container: expected } = render(
         <WithRouter
           routerMock={{
-            asPath: '/with-router/99&foo=bar',
+            asPath: '/with-router/99?foo=bar#moo',
             pathname: '/with-router/[id]',
             query: {
-              foo: 'bar',
               id: '99',
+              foo: 'bar',
             },
             route: '/with-router/[id]',
           }}

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -257,4 +257,14 @@ describe('getPage', () => {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('api pages', () => {
+    it('returns undefined', async () => {
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/api',
+      });
+      expect(actualPage).toBe(undefined);
+    });
+  });
 });

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -57,7 +57,15 @@ describe('getPage', () => {
         route: '/blog/5',
       });
       const { container: actual } = render(actualPage);
-      const { container: expected } = render(<BlogPage />);
+      const { container: expected } = render(
+        <BlogPage
+          routerMock={{
+            query: {
+              id: '5',
+            },
+          }}
+        />
+      );
       expect(actual).toEqual(expected);
     });
 
@@ -67,7 +75,16 @@ describe('getPage', () => {
         route: '/blog/5?foo=bar',
       });
       const { container: actual } = render(actualPage);
-      const { container: expected } = render(<BlogPage />);
+      const { container: expected } = render(
+        <BlogPage
+          routerMock={{
+            query: {
+              id: '5',
+              foo: 'bar',
+            },
+          }}
+        />
+      );
       expect(actual).toEqual(expected);
     });
 
@@ -82,27 +99,8 @@ describe('getPage', () => {
     });
   });
 
-  //@TODO: test it without getServerSideProps when next/router is supported
   describe('catch all routes', () => {
-    it('gets expected page object', async () => {
-      const actualPage = await getPage({
-        pagesDirectory,
-        route: '/catch-all/5/foo/bar/moo',
-      });
-      const { container: actual } = render(actualPage);
-      const { container: expected } = render(
-        <CatchAllPage
-          params={{
-            id: '5',
-            slug: ['foo', 'bar', 'moo'],
-          }}
-          query={{}}
-        />
-      );
-      expect(actual).toEqual(expected);
-    });
-
-    it('supports paths with query strings', async () => {
+    it('gets expected page object with params and querystring', async () => {
       const actualPage = await getPage({
         pagesDirectory,
         route: '/catch-all/5/foo/bar/moo?foo=bar',
@@ -110,11 +108,13 @@ describe('getPage', () => {
       const { container: actual } = render(actualPage);
       const { container: expected } = render(
         <CatchAllPage
-          params={{
-            id: '5',
-            slug: ['foo', 'bar', 'moo'],
+          routerMock={{
+            query: {
+              id: '5',
+              slug: ['foo', 'bar', 'moo'],
+              foo: 'bar',
+            },
           }}
-          query={{ foo: 'bar' }}
         />
       );
       expect(actual).toEqual(expected);
@@ -129,27 +129,8 @@ describe('getPage', () => {
     });
   });
 
-  //@TODO: test it without getServerSideProps when next/router is supported
   describe('optional catch all routes', () => {
-    it('gets expected page object', async () => {
-      const actualPage = await getPage({
-        pagesDirectory,
-        route: '/optional-catch-all/5/foo/bar/moo',
-      });
-      const { container: actual } = render(actualPage);
-      const { container: expected } = render(
-        <OptionalCatchAllPage
-          params={{
-            id: '5',
-            slug: ['foo', 'bar', 'moo'],
-          }}
-          query={{}}
-        />
-      );
-      expect(actual).toEqual(expected);
-    });
-
-    it('supports paths with query strings', async () => {
+    it('gets expected page object with params and querystring', async () => {
       const actualPage = await getPage({
         pagesDirectory,
         route: '/optional-catch-all/5/foo/bar/moo?foo=bar',
@@ -157,11 +138,13 @@ describe('getPage', () => {
       const { container: actual } = render(actualPage);
       const { container: expected } = render(
         <OptionalCatchAllPage
-          params={{
-            id: '5',
-            slug: ['foo', 'bar', 'moo'],
+          routerMock={{
+            query: {
+              id: '5',
+              slug: ['foo', 'bar', 'moo'],
+              foo: 'bar',
+            },
           }}
-          query={{ foo: 'bar' }}
         />
       );
       expect(actual).toEqual(expected);
@@ -175,10 +158,11 @@ describe('getPage', () => {
       const { container: actual } = render(actualPage);
       const { container: expected } = render(
         <OptionalCatchAllPage
-          params={{
-            id: '5',
+          routerMock={{
+            query: {
+              id: '5',
+            },
           }}
-          query={{}}
         />
       );
       expect(actual).toEqual(expected);
@@ -251,6 +235,24 @@ describe('getPage', () => {
             route: '/with-router/[id]',
           }}
         />
+      );
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('router option', () => {
+    it('return custom router object', async () => {
+      const routerMock = {
+        route: 'mocked',
+      };
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/with-router/99',
+        router: (router) => routerMock,
+      });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <WithRouter routerMock={routerMock} />
       );
       expect(actual).toEqual(expected);
     });

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import httpMocks from 'node-mocks-http';
 import getPage from '../getPage';
 import IndexPage from './__fixtures__/pages/index';
@@ -14,188 +16,229 @@ const pagesDirectory = __dirname + '/__fixtures__/pages';
 describe('getPage', () => {
   describe('route matching a page path', () => {
     it('gets expected component', async () => {
-      const actual = await getPage({ pagesDirectory, route: '/index' });
-      expect(actual).toEqual(React.createElement(IndexPage));
+      const actualPage = await getPage({ pagesDirectory, route: '/index' });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<IndexPage />);
+      expect(actual).toEqual(expected);
     });
   });
 
   describe('route not matching any page', () => {
     it('returns undefined', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/blog/5/doesntexists',
       });
-      expect(actual).toBe(undefined);
+      expect(actualPage).toBe(undefined);
     });
   });
 
   describe('route with trailing slash', () => {
     it('returns undefined', async () => {
-      const actual = await getPage({ pagesDirectory, route: '/blog/5/' });
-      expect(actual).toBe(undefined);
+      const actualPage = await getPage({ pagesDirectory, route: '/blog/5/' });
+      expect(actualPage).toBe(undefined);
     });
   });
 
   describe('pages files named "index"', () => {
     it('routes them to the root of the directory', async () => {
-      const actual = await getPage({ pagesDirectory, route: '/blog' });
-      expect(actual).toEqual(React.createElement(BlogIndexPage));
+      const actualPage = await getPage({ pagesDirectory, route: '/blog' });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<BlogIndexPage />);
+      expect(actual).toEqual(expected);
     });
   });
 
   describe('dynamic route segments', () => {
     it('gets expected page object', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/blog/5',
       });
-      expect(actual).toEqual(React.createElement(BlogPage));
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<BlogPage />);
+      expect(actual).toEqual(expected);
     });
 
     it('supports paths with query strings', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/blog/5?foo=bar',
       });
-      expect(actual).toEqual(React.createElement(BlogPage));
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<BlogPage />);
+      expect(actual).toEqual(expected);
     });
 
     it('predefined routes take precedence over dynamic', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/blog/99',
       });
-      expect(actual).toEqual(React.createElement(BlogPage99, {}));
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<BlogPage99 />);
+      expect(actual).toEqual(expected);
     });
   });
 
   //@TODO: test it without getServerSideProps when next/router is supported
   describe('catch all routes', () => {
     it('gets expected page object', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/catch-all/5/foo/bar/moo',
       });
-      expect(actual).toEqual(
-        React.createElement(CatchAllPage, {
-          params: {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <CatchAllPage
+          params={{
             id: '5',
             slug: ['foo', 'bar', 'moo'],
-          },
-          query: {},
-        })
+          }}
+          query={{}}
+        />
       );
+      expect(actual).toEqual(expected);
     });
 
     it('supports paths with query strings', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/catch-all/5/foo/bar/moo?foo=bar',
       });
-      expect(actual).toEqual(
-        React.createElement(CatchAllPage, {
-          params: {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <CatchAllPage
+          params={{
             id: '5',
             slug: ['foo', 'bar', 'moo'],
-          },
-          query: { foo: 'bar' },
-        })
+          }}
+          query={{ foo: 'bar' }}
+        />
       );
+      expect(actual).toEqual(expected);
     });
 
     it("doesn't match when no optional params are provided", async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/catch-all/5',
       });
-      expect(actual).toBe(undefined);
+      expect(actualPage).toBe(undefined);
     });
   });
 
   //@TODO: test it without getServerSideProps when next/router is supported
   describe('optional catch all routes', () => {
     it('gets expected page object', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/optional-catch-all/5/foo/bar/moo',
       });
-      expect(actual).toEqual(
-        React.createElement(OptionalCatchAllPage, {
-          params: {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <OptionalCatchAllPage
+          params={{
             id: '5',
             slug: ['foo', 'bar', 'moo'],
-          },
-          query: {},
-        })
+          }}
+          query={{}}
+        />
       );
+      expect(actual).toEqual(expected);
     });
 
     it('supports paths with query strings', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/optional-catch-all/5/foo/bar/moo?foo=bar',
       });
-      expect(actual).toEqual(
-        React.createElement(OptionalCatchAllPage, {
-          params: {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <OptionalCatchAllPage
+          params={{
             id: '5',
             slug: ['foo', 'bar', 'moo'],
-          },
-          query: { foo: 'bar' },
-        })
+          }}
+          query={{ foo: 'bar' }}
+        />
       );
+      expect(actual).toEqual(expected);
     });
 
     it('matches when no optional params are provided', async () => {
-      const actual = await getPage({
+      const actualPage = await getPage({
         pagesDirectory,
         route: '/optional-catch-all/5',
       });
-      expect(actual).toEqual(
-        React.createElement(OptionalCatchAllPage, {
-          params: {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <OptionalCatchAllPage
+          params={{
             id: '5',
-          },
-          query: {},
-        })
+          }}
+          query={{}}
+        />
       );
+      expect(actual).toEqual(expected);
     });
   });
 
   describe('page with getServerSideProps', () => {
     it('feeds page component with returned props', async () => {
-      const actual = await getPage({ pagesDirectory, route: '/ssr/5?foo=bar' });
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/ssr/5?foo=bar',
+      });
+
       const expectedParams = { id: '5' };
       const expectedQuery = { foo: 'bar' };
-      const expectedReq = httpMocks.createRequest({
-        url: '/ssr/5?foo=bar',
-        params: expectedParams,
-        query: expectedQuery,
-      });
-      const expectedRes = httpMocks.createResponse();
 
-      //@HACK here props property order counts
-      expect(JSON.stringify(actual)).toEqual(
-        JSON.stringify(
-          React.createElement(SSRPage, {
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <SSRPage
+          params={expectedParams}
+          query={expectedQuery}
+          req={httpMocks.createRequest({
+            url: '/ssr/5?foo=bar',
             params: expectedParams,
             query: expectedQuery,
-            req: expectedReq,
-            res: expectedRes,
-          })
-        )
+          })}
+          res={httpMocks.createResponse()}
+        />
       );
+
+      expect(actual).toEqual(expected);
     });
   });
 
   describe('page with getStaticProps', () => {
     it('feeds page component with returned props', async () => {
-      const actual = await getPage({ pagesDirectory, route: '/ssg/5?foo=bar' });
-      expect(actual).toEqual(
-        React.createElement(SSGPage, {
-          params: { id: '5' },
-        })
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/ssg/5?foo=bar',
+      });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <SSGPage
+          params={{
+            id: '5',
+          }}
+        />
       );
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('with Next router', () => {
+    it('receives expected router object', async () => {
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/with-router/99',
+      });
+
+      const { container } = render(actualPage);
+      expect(container).toHaveTextContent(99);
     });
   });
 });

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -11,6 +11,7 @@ import CatchAllPage from './__fixtures__/pages/catch-all/[id]/[...slug]';
 import OptionalCatchAllPage from './__fixtures__/pages/optional-catch-all/[id]/[[...slug]]';
 import SSRPage from './__fixtures__/pages/ssr/[id]';
 import SSGPage from './__fixtures__/pages/ssg/[id]';
+import WithRouter from './__fixtures__/pages/with-router/[id]';
 const pagesDirectory = __dirname + '/__fixtures__/pages';
 
 describe('getPage', () => {
@@ -234,11 +235,24 @@ describe('getPage', () => {
     it('receives expected router object', async () => {
       const actualPage = await getPage({
         pagesDirectory,
-        route: '/with-router/99',
+        route: '/with-router/99&foo=bar',
       });
 
-      const { container } = render(actualPage);
-      expect(container).toHaveTextContent(99);
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <WithRouter
+          routerMock={{
+            asPath: '/with-router/99&foo=bar',
+            pathname: '/with-router/[id]',
+            query: {
+              foo: 'bar',
+              id: '99',
+            },
+            route: '/with-router/[id]',
+          }}
+        />
+      );
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/src/fetchData.js
+++ b/src/fetchData.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import queryString from 'query-string';
+import httpMocks from 'node-mocks-http';
+import { parseRoute } from './utils';
+
+export default async function fetchData({
+  pageObject: { page, params, route, req, res },
+}) {
+  if (page.getServerSideProps) {
+    // @TODO complete ctx object
+    // https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+    const { search } = parseRoute({ route });
+    const query = queryString.parse(search);
+    const ctx = {
+      params: { ...params },
+      query,
+      req: {
+        ...httpMocks.createRequest({
+          url: route,
+          params: { ...params },
+          query,
+        }),
+        ...req,
+      },
+      res: {
+        ...httpMocks.createResponse(),
+        ...res,
+      },
+    };
+    const result = await page.getServerSideProps(ctx);
+    return React.createElement(page.default, result.props);
+  }
+
+  if (page.getStaticProps) {
+    // @TODO complete ctx object
+    // https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
+    const ctx = {
+      params: { ...params },
+    };
+    // @TODO introduce `getStaticPaths` logic
+    // https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
+    const result = await page.getStaticProps(ctx);
+    return React.createElement(page.default, result.props);
+  }
+
+  return React.createElement(page.default);
+}

--- a/src/fetchData.js
+++ b/src/fetchData.js
@@ -4,7 +4,9 @@ import httpMocks from 'node-mocks-http';
 import { parseRoute } from './utils';
 
 export default async function fetchData({
-  pageObject: { page, params, route, req, res },
+  pageObject: { page, params, route },
+  reqMocker,
+  resMocker,
 }) {
   if (page.getServerSideProps) {
     // @TODO complete ctx object
@@ -14,18 +16,14 @@ export default async function fetchData({
     const ctx = {
       params: { ...params },
       query,
-      req: {
-        ...httpMocks.createRequest({
+      req: reqMocker(
+        httpMocks.createRequest({
           url: route,
           params: { ...params },
           query,
-        }),
-        ...req,
-      },
-      res: {
-        ...httpMocks.createResponse(),
-        ...res,
-      },
+        })
+      ),
+      res: resMocker(httpMocks.createResponse()),
     };
     const result = await page.getServerSideProps(ctx);
     return React.createElement(page.default, result.props);

--- a/src/getPage.js
+++ b/src/getPage.js
@@ -5,12 +5,12 @@ import preparePage from './preparePage';
 export default async function getPage({
   pagesDirectory,
   route,
-  req = {},
-  res = {},
+  req: reqMocker = (req) => req,
+  res: resMocker = (res) => res,
 }) {
   const pageObject = await getPageObject({ pagesDirectory, route });
   if (pageObject) {
-    let pageElement = await fetchData({ pageObject, req, res });
+    let pageElement = await fetchData({ pageObject, reqMocker, resMocker });
     pageElement = preparePage({ pageElement, pageObject });
     return pageElement;
   }

--- a/src/getPage.js
+++ b/src/getPage.js
@@ -7,11 +7,12 @@ export default async function getPage({
   route,
   req: reqMocker = (req) => req,
   res: resMocker = (res) => res,
+  router: routerMocker = (router) => router,
 }) {
   const pageObject = await getPageObject({ pagesDirectory, route });
   if (pageObject) {
     let pageElement = await fetchData({ pageObject, reqMocker, resMocker });
-    pageElement = preparePage({ pageElement, pageObject });
+    pageElement = preparePage({ pageElement, pageObject, routerMocker });
     return pageElement;
   }
 }

--- a/src/getPage.js
+++ b/src/getPage.js
@@ -1,4 +1,5 @@
 import getPageObject from './getPageObject';
+import fetchData from './fetchData';
 import preparePage from './preparePage';
 
 export default async function getPage({
@@ -9,7 +10,8 @@ export default async function getPage({
 }) {
   const pageObject = await getPageObject({ pagesDirectory, route });
   if (pageObject) {
-    const pageComponent = await preparePage({ pageObject, req, res });
-    return pageComponent;
+    let pageElement = await fetchData({ pageObject, req, res });
+    pageElement = preparePage({ pageElement, pageObject });
+    return pageElement;
   }
 }

--- a/src/getPagePaths.js
+++ b/src/getPagePaths.js
@@ -1,10 +1,17 @@
 import path from 'path';
 import readdir from 'recursive-readdir';
 
+function makeIgnoreFunc(pagesDirectory) {
+  return (file, stats) => {
+    return file.startsWith(pagesDirectory + '/api/');
+  };
+}
+
 async function getPagePaths({ pagesDirectory }) {
+  const ignoreFunc = makeIgnoreFunc(pagesDirectory);
   let files = [];
   try {
-    files = await readdir(pagesDirectory);
+    files = await readdir(pagesDirectory, [ignoreFunc]);
   } catch (err) {
     throw new Error(`[next testing] ${err}`);
   }

--- a/src/preparePage.js
+++ b/src/preparePage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import queryString from 'query-string';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import { parseRoute, removeFileExtension } from './utils';
 
@@ -32,15 +33,15 @@ export default function preparePage({
   pageObject: { pagePath, params, route },
   routerMocker,
 }) {
-  const { pathname, search } = parseRoute({ route });
+  const { pathname, search, hash } = parseRoute({ route });
   return React.createElement(
     RouterContext.Provider,
     {
       value: routerMocker(
         makeDefaultRouterMock({
-          asPath: pathname + search, // Includes querystring and anchor
+          asPath: pathname + search + hash, // Includes querystring and anchor
           pathname: removeFileExtension({ path: pagePath }), // Page component path without extension
-          query: params, // Route params + parsed querystring
+          query: { ...params, ...queryString.parse(search) }, // Route params + parsed querystring
           route: removeFileExtension({ path: pagePath }), // Page component path without extension
         })
       ),

--- a/src/preparePage.js
+++ b/src/preparePage.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
-import { parseRoute } from './utils';
+import { parseRoute, removeFileExtension } from './utils';
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
 function makeDefaultRouterMock(props) {
@@ -32,15 +32,16 @@ export default function preparePage({
   pageObject: { pagePath, params, route },
   routerMocker,
 }) {
-  const { pathname } = parseRoute(route);
+  const { pathname, search } = parseRoute({ route });
   return React.createElement(
     RouterContext.Provider,
     {
       value: routerMocker(
         makeDefaultRouterMock({
-          pathname: pagePath,
-          asPath: pathname,
-          query: params,
+          asPath: pathname + search, // Includes querystring and anchor
+          pathname: removeFileExtension({ path: pagePath }), // Page component path without extension
+          query: params, // Route params + parsed querystring
+          route: removeFileExtension({ path: pagePath }), // Page component path without extension
         })
       ),
     },

--- a/src/preparePage.js
+++ b/src/preparePage.js
@@ -3,41 +3,46 @@ import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import { parseRoute } from './utils';
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
-const routerMock = {
-  basePath: '',
-  pathname: '/',
-  route: '/',
-  asPath: '/',
-  query: {},
-  push: () => {},
-  replace: () => {},
-  reload: () => {},
-  back: () => {},
-  prefetch: () => {},
-  beforePopState: () => {},
-  events: {
-    on: () => {},
-    off: () => {},
-    emit: () => {},
-  },
-  isFallback: false,
-};
+function makeDefaultRouterMock(props) {
+  const routerMock = {
+    basePath: '',
+    pathname: '/',
+    route: '/',
+    asPath: '/',
+    query: {},
+    push: () => {},
+    replace: () => {},
+    reload: () => {},
+    back: () => {},
+    prefetch: () => {},
+    beforePopState: () => {},
+    events: {
+      on: () => {},
+      off: () => {},
+      emit: () => {},
+    },
+    isFallback: false,
+  };
+
+  return { ...routerMock, ...props };
+}
 
 export default function preparePage({
   pageElement,
   pageObject: { pagePath, params, route },
+  routerMocker,
 }) {
   const { pathname } = parseRoute(route);
   return React.createElement(
     RouterContext.Provider,
     {
-      value: {
-        ...routerMock,
-        // @TODO review these values
-        pathname: pagePath,
-        asPath: pathname,
-        query: params,
-      },
+      value: routerMocker(
+        makeDefaultRouterMock({
+          pathname: pagePath,
+          asPath: pathname,
+          query: params,
+        })
+      ),
     },
     pageElement
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,3 +7,7 @@ export function sleep(ms) {
     setTimeout(resolve, ms);
   });
 }
+
+export function removeFileExtension({ path }) {
+  return path.replace(/\.[^/.]+$/, '');
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Next `useRoute` not supported

## What is the new behaviour?

Provide returned page with Next router's router provider supplying a mocked router

## Other information:

Improve mocks customisation.

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
