### PR TITLE
Typescript refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 0.2.0
+
+### Breaking Changes
+
+- Expose Typescript types
+
+### New Features
+
+- Migrate codebase to Typescript
+- Replace query-string with node's querystring
+
+## 0.1.0
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Next page tester will take care of:
 
 ## Options
 
-| Property           | Description                                                                        | type               | Default |
-| ------------------ | ---------------------------------------------------------------------------------- | ------------------ | ------- |
-| **route**          | Next route (must start with `/`)                                                   | -                  | -       |
-| **pagesDirectory** | Absolute path of Next's `/pages` folder                                            | -                  | -       |
-| **req**            | Override default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -       |
-| **res**            | Override default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -       |
-| **router**         | Override default mocked [Next router object][next-docs-router]                     | `router => router` | -       |
+| Property           | Description                                                                      | type               | Default |
+| ------------------ | -------------------------------------------------------------------------------- | ------------------ | ------- |
+| **route**          | Next route (must start with `/`)                                                 | -                  | -       |
+| **pagesDirectory** | Absolute path of Next's `/pages` folder                                          | -                  | -       |
+| **req**            | Access default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -       |
+| **res**            | Access default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -       |
+| **router**         | Access default mocked [Next router object][next-docs-router]                     | `router => router` | -       |
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 - Make available dynamic api routes under `/pages/api`
 - Consider adding custom App and Document
 - Consider adding a `getPage` factory
+- Consider reusing Next.js code parts (not only types)
 
 [ci]: https://travis-ci.com/toomuchdesign/next-page-tester
 [ci-badge]: https://travis-ci.com/toomuchdesign/next-page-tester.svg?branch=master

--- a/package-lock.json
+++ b/package-lock.json
@@ -3916,7 +3916,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "dedent": {
       "version": "0.7.0",
@@ -7554,16 +7555,6 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "query-string": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
-      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
-      "requires": {
-        "decode-uri-component": "^0.2.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      }
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -8912,11 +8903,6 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
-    "split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -9071,11 +9057,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-argv": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "clean": "rm -rf dist",
     "compile": "npm run clean && tsc",
     "test": "jest ./src",
-    "test:source": "npm t -- --coverage",
+    "test:source": "npm run test:ts && npm t -- --coverage",
+    "test:ts": "tsc --noEmit",
     "prepare": "npm run test:source && npm run compile",
     "preversion": "npm run prepare",
     "version": "git add package.json",
@@ -88,7 +89,7 @@
   "lint-staged": {
     "**/*.{js,ts,json}": [
       "prettier",
-      "npm t -- ."
+      "npm run test:source -- ."
     ],
     "**/*.{md}": [
       "prettier"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/express": "^4.17.8",
     "@types/recursive-readdir": "^2.2.0",
     "node-mocks-http": "^1.9.0",
-    "query-string": "^6.13.1",
     "recursive-readdir": "^2.2.2"
   },
   "peerDependencies": {

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -12,8 +12,8 @@ type Res = ReturnType<typeof createResponse>;
 export type Options = {
   route: string;
   pagesDirectory: string;
-  req?: (req: Req) => { [name: string]: any };
-  res?: (res: Res) => { [name: string]: any };
+  req?: (req: Req) => Req;
+  res?: (res: Res) => Res;
   router?: (router: NextRouter) => NextRouter;
 };
 

--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -1,12 +1,11 @@
 import React, { ReactNode } from 'react';
-import queryString from 'query-string';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import type { NextRouter } from 'next/router';
-import { parseRoute, removeFileExtension } from './utils';
+import { parseRoute, removeFileExtension, parseQueryString } from './utils';
 import type { Options, PageObject } from './commonTypes';
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
-function makeDefaultRouterMock(props?: {}): NextRouter {
+function makeDefaultRouterMock(props?: Partial<NextRouter>): NextRouter {
   const routerMock = {
     basePath: '',
     pathname: '/',
@@ -47,7 +46,7 @@ export default function preparePage({
         makeDefaultRouterMock({
           asPath: pathname + search + hash, // Includes querystring and anchor
           pathname: removeFileExtension({ path: pagePath }), // Page component path without extension
-          query: { ...params, ...queryString.parse(search) }, // Route params + parsed querystring
+          query: { ...params, ...parseQueryString({ queryString: search }) }, // Route params + parsed querystring
           route: removeFileExtension({ path: pagePath }), // Page component path without extension
         })
       ),

--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -6,15 +6,15 @@ import { parseRoute, removeFileExtension } from './utils';
 import type { Options, PageObject } from './commonTypes';
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
-function makeDefaultRouterMock(props = {}): NextRouter {
+function makeDefaultRouterMock(props?: {}): NextRouter {
   const routerMock = {
     basePath: '',
     pathname: '/',
     route: '/',
     asPath: '/',
     query: {},
-    push: async () => true,
-    replace: async () => true,
+    push: /* istanbul ignore next */ async () => true,
+    replace: /* istanbul ignore next */ async () => true,
     reload: () => {},
     back: () => {},
     prefetch: async () => {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,11 @@
-const url = require('url');
+import { URL } from 'url';
 import querystring from 'querystring';
 
 export function parseRoute({ route }: { route: string }) {
-  return url.parse(`http://test.com${route}`);
+  return new URL(`http://test.com${route}`);
 }
 
-export function parseQueryString({ queryString }: { queryString?: string }) {
-  if (typeof queryString !== 'string') return {};
+export function parseQueryString({ queryString }: { queryString: string }) {
   const qs = queryString.startsWith('?')
     ? queryString.substring(1)
     : queryString;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,17 @@
 const url = require('url');
+import querystring from 'querystring';
 
 export function parseRoute({ route }: { route: string }) {
   return url.parse(`http://test.com${route}`);
+}
+
+export function parseQueryString({ queryString }: { queryString?: string }) {
+  if (typeof queryString !== 'string') return {};
+  const qs = queryString.startsWith('?')
+    ? queryString.substring(1)
+    : queryString;
+
+  return querystring.parse(qs);
 }
 
 export function sleep(ms: number) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor improvements

## What is the new behaviour?

- Exclude routerMock props from code coverage
- Fasten `makeDefaultRouterMock` types
- Replace query-string with node's querystring
- Switch from url to URL

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
