### PR TITLE
Optionally wrap page with app component

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Next page tester will take care of:
 | **req**            | Access default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -       |
 | **res**            | Access default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -       |
 | **router**         | Access default mocked [Next router object][next-docs-router]                     | `router => router` | -       |
+| **customApp**      | Use [custom App component ][next-docs-custom-app]                                | `boolean`          | `false` |
 
 ## Notes
 
@@ -59,8 +60,8 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 ## Todo's
 
 - Make available dynamic api routes under `/pages/api`
-- Add support for `getInitialProps`
-- Consider adding custom App and Document
+- Add support for `getInitialProps` (in custom App and Pages)
+- Consider adding custom Document
 - Consider adding a `getPage` factory
 - Consider reusing Next.js code parts (not only types)
 
@@ -77,4 +78,5 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 [next-docs-routing]: https://nextjs.org/docs/routing/introduction
 [next-docs-data-fetching]: https://nextjs.org/docs/basic-features/data-fetching
 [next-docs-router]: https://nextjs.org/docs/api-reference/next/router
+[next-docs-custom-app]: https://nextjs.org/docs/advanced-features/custom-app
 [next-gh-strict-bug]: https://github.com/vercel/next.js/issues/16219

--- a/src/__tests__/__fixtures__/pages/_app.js
+++ b/src/__tests__/__fixtures__/pages/_app.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function CustomApp({ Component, pageProps }) {
+  return (
+    <>
+      '_app'
+      <Component {...pageProps} />;
+    </>
+  );
+}

--- a/src/__tests__/__fixtures__/pages/_document.js
+++ b/src/__tests__/__fixtures__/pages/_document.js
@@ -1,0 +1,3 @@
+export default function CustomDocument() {
+  return '_document';
+}

--- a/src/__tests__/__fixtures__/pages/custom-app/[id].js
+++ b/src/__tests__/__fixtures__/pages/custom-app/[id].js
@@ -1,0 +1,14 @@
+import { sleep } from '../../../../utils';
+
+export default function customApp_$id$(props) {
+  return `/custom-app/[id] - props: ${JSON.stringify(props)}`;
+}
+
+export async function getServerSideProps(ctx) {
+  await sleep(1);
+  return {
+    props: {
+      params: ctx.params,
+    },
+  };
+}

--- a/src/__tests__/__fixtures__/pages/invalid-extension.foo
+++ b/src/__tests__/__fixtures__/pages/invalid-extension.foo
@@ -1,0 +1,3 @@
+export default function index(props) {
+  return `/index - props: ${JSON.stringify(props)}`;
+}

--- a/src/__tests__/__fixtures__/pages/typescript.ts
+++ b/src/__tests__/__fixtures__/pages/typescript.ts
@@ -1,0 +1,3 @@
+export default function typescript() {
+  return '/typescript';
+}

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -41,6 +41,20 @@ describe('getPage', () => {
     });
   });
 
+  describe('route === "_app"', () => {
+    it('returns undefined', async () => {
+      const actualPage = await getPage({ pagesDirectory, route: '/_app' });
+      expect(actualPage).toBe(undefined);
+    });
+  });
+
+  describe('route === "_document"', () => {
+    it('returns undefined', async () => {
+      const actualPage = await getPage({ pagesDirectory, route: '/_document' });
+      expect(actualPage).toBe(undefined);
+    });
+  });
+
   describe('pages files named "index"', () => {
     it('routes them to the root of the directory', async () => {
       const actualPage = await getPage({ pagesDirectory, route: '/blog' });

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -11,8 +11,10 @@ import BlogPage99 from './__fixtures__/pages/blog/99';
 import CatchAllPage from './__fixtures__/pages/catch-all/[id]/[...slug]';
 import OptionalCatchAllPage from './__fixtures__/pages/optional-catch-all/[id]/[[...slug]]';
 import SSRPage from './__fixtures__/pages/ssr/[id]';
+import CustomApp from './__fixtures__/pages/custom-app/[id]';
 import SSGPage from './__fixtures__/pages/ssg/[id]';
 import WithRouter from './__fixtures__/pages/with-router/[id]';
+import CustomAppComponent from './__fixtures__/pages/_app';
 const pagesDirectory = __dirname + '/__fixtures__/pages';
 
 describe('getPage', () => {
@@ -68,7 +70,7 @@ describe('getPage', () => {
     });
   });
 
-  describe.only('route matching page file with invalid extension', () => {
+  describe('route matching page file with invalid extension', () => {
     it('returns undefined', async () => {
       const actualPage = await getPage({
         pagesDirectory,
@@ -327,6 +329,28 @@ describe('getPage', () => {
           })
         ).rejects.toThrow('[next page tester]');
       });
+    });
+  });
+
+  describe('custom App component', () => {
+    it('wraps expected page with _app component', async () => {
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/custom-app/5',
+        customApp: true,
+      });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(
+        <CustomAppComponent
+          Component={CustomApp}
+          pageProps={{
+            params: {
+              id: '5',
+            },
+          }}
+        />
+      );
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/src/__tests__/getPage.test.js
+++ b/src/__tests__/getPage.test.js
@@ -4,6 +4,7 @@ import '@testing-library/jest-dom';
 import httpMocks from 'node-mocks-http';
 import { getPage } from '../index';
 import IndexPage from './__fixtures__/pages/index';
+import TypescriptPage from './__fixtures__/pages/typescript.ts';
 import BlogIndexPage from './__fixtures__/pages/blog/index';
 import BlogPage from './__fixtures__/pages/blog/[id]';
 import BlogPage99 from './__fixtures__/pages/blog/99';
@@ -51,6 +52,28 @@ describe('getPage', () => {
   describe('route === "_document"', () => {
     it('returns undefined', async () => {
       const actualPage = await getPage({ pagesDirectory, route: '/_document' });
+      expect(actualPage).toBe(undefined);
+    });
+  });
+
+  describe('route matching page with .ts extension', () => {
+    it('returns undefined', async () => {
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/typescript',
+      });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<TypescriptPage />);
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe.only('route matching page file with invalid extension', () => {
+    it('returns undefined', async () => {
+      const actualPage = await getPage({
+        pagesDirectory,
+        route: '/invalid-extension',
+      });
       expect(actualPage).toBe(undefined);
     });
   });

--- a/src/__tests__/pagePathToRegex.test.js
+++ b/src/__tests__/pagePathToRegex.test.js
@@ -3,7 +3,7 @@ import pagePathToRouteRegex from '../pagePathToRouteRegex';
 describe('pagePathToRouteRegex', () => {
   describe('predefined routes', () => {
     it('gets expected regex', () => {
-      const actual = pagePathToRouteRegex('/index.js');
+      const actual = pagePathToRouteRegex('/index');
       const expected = new RegExp('^(?:/index)?$').toString();
       expect(actual.toString()).toBe(expected);
     });
@@ -11,7 +11,7 @@ describe('pagePathToRouteRegex', () => {
 
   describe('dynamic segments', () => {
     it('gets expected regex', () => {
-      const actual = pagePathToRouteRegex('/blog/[id]/[foo]/index.js');
+      const actual = pagePathToRouteRegex('/blog/[id]/[foo]/index');
       const expected = new RegExp(
         `^/blog/(?<id>[^/?]*)/(?<foo>[^/?]*)(?:/index)?$`
       ).toString();
@@ -22,7 +22,7 @@ describe('pagePathToRouteRegex', () => {
 
   describe('catch all segments', () => {
     it('gets expected regex', () => {
-      const actual = pagePathToRouteRegex('/blog/[id]/[...foo]/index.js');
+      const actual = pagePathToRouteRegex('/blog/[id]/[...foo]/index');
       const expected = new RegExp(
         `^/blog/(?<id>[^/?]*)/(?<foo>.*?)(?:/index)?$`
       ).toString();
@@ -33,7 +33,7 @@ describe('pagePathToRouteRegex', () => {
 
   describe('optional catch all segments', () => {
     it('gets expected regex', () => {
-      const actual = pagePathToRouteRegex('/blog/[id]/[[...foo]]/index.js');
+      const actual = pagePathToRouteRegex('/blog/[id]/[[...foo]]/index');
       const expected = new RegExp(
         `^/blog/(?<id>[^/?]*)(?:\/)?(?<foo>.*?)?(?:/index)?$`
       ).toString();

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -34,3 +34,11 @@ export type PageObject = {
   params: PageParams;
   paramsNumber: number;
 };
+
+export type PageData =
+  | {
+      props: {
+        [key: string]: any;
+      };
+    }
+  | undefined;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -15,6 +15,7 @@ export type Options = {
   req?: (req: Req) => Req;
   res?: (res: Res) => Res;
   router?: (router: NextRouter) => NextRouter;
+  customApp?: boolean;
 };
 
 export type NextPageFile = {

--- a/src/fetchData.ts
+++ b/src/fetchData.ts
@@ -1,6 +1,5 @@
-import React, { ReactNode } from 'react';
 import httpMocks from 'node-mocks-http';
-import type { Options, PageObject } from './commonTypes';
+import type { Options, PageObject, PageData } from './commonTypes';
 
 export default async function fetchData({
   pageObject: { page, params, route },
@@ -10,7 +9,7 @@ export default async function fetchData({
   pageObject: PageObject;
   reqMocker: Exclude<Options['req'], undefined>;
   resMocker: Exclude<Options['res'], undefined>;
-}): Promise<ReactNode> {
+}): Promise<PageData> {
   if (page.getServerSideProps) {
     // @TODO complete ctx object
     // https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
@@ -27,8 +26,7 @@ export default async function fetchData({
     };
 
     // @ts-ignore: Types of property 'req' are incompatible
-    const result = await page.getServerSideProps(ctx);
-    return React.createElement(page.default, result.props);
+    return await page.getServerSideProps(ctx);
   }
 
   if (page.getStaticProps) {
@@ -39,9 +37,6 @@ export default async function fetchData({
     };
     // @TODO introduce `getStaticPaths` logic
     // https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
-    const result = await page.getStaticProps(ctx);
-    return React.createElement(page.default, result.props);
+    return await page.getStaticProps(ctx);
   }
-
-  return React.createElement(page.default);
 }

--- a/src/getPage.ts
+++ b/src/getPage.ts
@@ -21,8 +21,12 @@ export default async function getPage({
 
   const pageObject = await getPageObject({ pagesDirectory, route });
   if (pageObject) {
-    let pageElement = await fetchData({ pageObject, reqMocker, resMocker });
-    pageElement = preparePage({ pageElement, pageObject, routerMocker });
+    const pageData = await fetchData({ pageObject, reqMocker, resMocker });
+    const pageElement = preparePage({
+      pageData,
+      pageObject,
+      routerMocker,
+    });
     return pageElement;
   }
 }

--- a/src/getPage.ts
+++ b/src/getPage.ts
@@ -16,6 +16,7 @@ export default async function getPage({
   req: reqMocker = (req) => req,
   res: resMocker = (res) => res,
   router: routerMocker = (router) => router,
+  customApp = false,
 }: Options): Promise<ReactNode | undefined> {
   validateOptions({ route });
 
@@ -23,9 +24,11 @@ export default async function getPage({
   if (pageObject) {
     const pageData = await fetchData({ pageObject, reqMocker, resMocker });
     const pageElement = preparePage({
+      pagesDirectory,
       pageData,
       pageObject,
       routerMocker,
+      customApp,
     });
     return pageElement;
   }

--- a/src/getPagePaths.ts
+++ b/src/getPagePaths.ts
@@ -21,6 +21,8 @@ async function getPagePaths({
     files
       // Make page paths relative
       .map((filePath) => filePath.replace(pagesDirectoryAbs, ''))
+      // Filter out files with non-allowed extensions
+      .filter((filePath) => filePath.match(extensionsRegex))
       // Strip file extensions
       .map((filePath) => filePath.replace(extensionsRegex, ''))
       // Filter out /api folder

--- a/src/getPagePaths.ts
+++ b/src/getPagePaths.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import readdir from 'recursive-readdir';
 
+// Returns available page paths without file extension
 async function getPagePaths({
   pagesDirectory,
 }: {
@@ -14,14 +15,17 @@ async function getPagePaths({
   }
 
   const pagesDirectoryAbs = path.resolve(pagesDirectory);
+  // @TODO Make allowed extensions configurable
+  const extensionsRegex = /\.(?:mdx|jsx|js|ts|tsx)$/;
   return files
     .map((filePath) => filePath.replace(pagesDirectoryAbs, ''))
-    .filter((filename) => {
-      if (filename.startsWith('/api/')) {
+    .filter((filePath) => {
+      if (filePath.startsWith('/api/')) {
         return false;
       }
       return true;
-    });
+    })
+    .map((filePath) => filePath.replace(extensionsRegex, ''));
 }
 
 export default getPagePaths;

--- a/src/getPagePaths.ts
+++ b/src/getPagePaths.ts
@@ -1,28 +1,27 @@
 import path from 'path';
 import readdir from 'recursive-readdir';
 
-function makeIgnoreFunc(pagesDirectory: string) {
-  return (file: string) => {
-    return file.startsWith(pagesDirectory + '/api/');
-  };
-}
-
 async function getPagePaths({
   pagesDirectory,
 }: {
   pagesDirectory: string;
 }): Promise<string[]> {
-  const ignoreFunc = makeIgnoreFunc(pagesDirectory);
   let files = [];
   try {
-    files = await readdir(pagesDirectory, [ignoreFunc]);
+    files = await readdir(pagesDirectory);
   } catch (err) {
     throw new Error(`[next page tester] ${err}`);
   }
 
-  return files.map((filePath) =>
-    filePath.replace(`${path.resolve(pagesDirectory)}`, '')
-  );
+  const pagesDirectoryAbs = path.resolve(pagesDirectory);
+  return files
+    .map((filePath) => filePath.replace(pagesDirectoryAbs, ''))
+    .filter((filename) => {
+      if (filename.startsWith('/api/')) {
+        return false;
+      }
+      return true;
+    });
 }
 
 export default getPagePaths;

--- a/src/getPagePaths.ts
+++ b/src/getPagePaths.ts
@@ -17,15 +17,17 @@ async function getPagePaths({
   const pagesDirectoryAbs = path.resolve(pagesDirectory);
   // @TODO Make allowed extensions configurable
   const extensionsRegex = /\.(?:mdx|jsx|js|ts|tsx)$/;
-  return files
-    .map((filePath) => filePath.replace(pagesDirectoryAbs, ''))
-    .filter((filePath) => {
-      if (filePath.startsWith('/api/')) {
-        return false;
-      }
-      return true;
-    })
-    .map((filePath) => filePath.replace(extensionsRegex, ''));
+  return (
+    files
+      // Make page paths relative
+      .map((filePath) => filePath.replace(pagesDirectoryAbs, ''))
+      // Strip file extensions
+      .map((filePath) => filePath.replace(extensionsRegex, ''))
+      // Filter out /api folder
+      .filter((filePath) => !filePath.startsWith('/api/'))
+      // Filter out /_app and /_document files
+      .filter((filePath) => filePath !== '/_app' && filePath !== '/_document')
+  );
 }
 
 export default getPagePaths;

--- a/src/pagePathToRouteRegex.ts
+++ b/src/pagePathToRouteRegex.ts
@@ -13,8 +13,6 @@ const OPTIONAL_CATCH_ALL_PATH_SEGMENT_REGEX_STRING = '.*?';
 const TRAILING_INDEX_REGEX = /\/index$/;
 const OPTIONAL_TRAILING_INDEX_REGEX_STRING = '(?:/index)?';
 
-const FILE_EXTENSION_REGEX = /\.[a-zA-Z0-9]*$/;
-
 type namedCapture = {
   name: string;
   regex: string;
@@ -32,7 +30,6 @@ function makeOptionalNamedCapturingGroup({ name, regex }: namedCapture) {
 // Build a regex from a page path to catch its matching routes
 function pagePathToRouteRegex(pagePath: string): RegExp {
   const regex = pagePath
-    .replace(FILE_EXTENSION_REGEX, '')
     .replace(TRAILING_INDEX_REGEX, OPTIONAL_TRAILING_INDEX_REGEX_STRING)
     .replace(OPTIONAL_CATCH_ALL_ROUTE_SEGMENT_REGEX, (match, paramName) => {
       const captureGroup = makeOptionalNamedCapturingGroup({

--- a/src/preparePage.ts
+++ b/src/preparePage.ts
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import type { NextRouter } from 'next/router';
 import { parseRoute, removeFileExtension, parseQueryString } from './utils';
-import type { Options, PageObject } from './commonTypes';
+import type { Options, PageObject, PageData } from './commonTypes';
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
 function makeDefaultRouterMock(props?: Partial<NextRouter>): NextRouter {
@@ -30,14 +30,21 @@ function makeDefaultRouterMock(props?: Partial<NextRouter>): NextRouter {
 }
 
 export default function preparePage({
-  pageElement,
-  pageObject: { pagePath, params, route },
+  pageData,
+  pageObject: { page, pagePath, params, route },
   routerMocker,
 }: {
-  pageElement: ReactNode;
+  pageData: PageData;
   pageObject: PageObject;
   routerMocker: Exclude<Options['router'], undefined>;
-}) {
+}): ReactNode {
+  // Render page element
+  const props = pageData?.props;
+  const pageElement = React.createElement(page.default, props);
+
+  // Wrap with custom App
+
+  // Wrap with RouterContext provider
   const { pathname, search, hash } = parseRoute({ route });
   return React.createElement(
     RouterContext.Provider,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Custom App component not implemented

## What is the new behaviour?

- Add `customApp` option to render custom App component.
- Filter out custom App and Document from routing results
- Pre filter out pages with non-allowed file extensions

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
