### PR TITLE
Support pages' getInitialProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ describe('Blog page', () => {
 
 ## What
 
-The idea behind this library is to enable integration tests on Next.js pages including [server side data fetching][next-docs-data-fetching] and [routing][next-docs-routing].
+The idea behind this library is to enable DOM integration tests on Next.js pages along with [server side data fetching][next-docs-data-fetching] and [routing][next-docs-routing].
 
-The testing approach suggested here consists of manually mocking external API's and get the component instance matching a given route.
+The testing approach suggested here consists of manually mocking external API's dependencies and get the component instance matching a given route.
 
 Next page tester will take care of:
 
 - **resolving** provided **routes** into the matching page component
-- calling **Next.js data fetching methods** (`getServerSideProps` or `getStaticProps`) if the case
+- calling **Next.js data fetching methods** (`getServerSideProps`, `getInitialProps` or `getStaticProps`) if the case
 - set up a **mocked `next/router` provider** initialized with the expected values (to test `useRouter` and `withRouter`)
 - **instantiating** the page component with the **expected props**
 
@@ -51,7 +51,7 @@ Next page tester will take care of:
 
 ## Notes
 
-`req` and `res` objects are mocked with [node-mocks-http][node-mocks-http].
+Data fetching methods' context `req` and `res` objects are mocked with [node-mocks-http][node-mocks-http].
 
 Next page tester can be used with any testing framework/library.
 
@@ -60,7 +60,7 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 ## Todo's
 
 - Make available dynamic api routes under `/pages/api`
-- Add support for `getInitialProps` (in custom App and Pages)
+- Add support for custom App's `getInitialProps`
 - Consider adding custom Document
 - Consider adding a `getPage` factory
 - Consider reusing Next.js code parts (not only types)

--- a/src/__tests__/__fixtures__/pages/gip/[id].js
+++ b/src/__tests__/__fixtures__/pages/gip/[id].js
@@ -1,0 +1,10 @@
+import { sleep } from '../../../../utils';
+
+export default function gip_$id$(props) {
+  return `/gip/[id] - props: ${JSON.stringify(props)}`;
+}
+
+gip_$id$.getInitialProps = async (ctx) => {
+  await sleep(1);
+  return ctx;
+};

--- a/src/__tests__/__fixtures__/pages/multiple-data-fetching.js
+++ b/src/__tests__/__fixtures__/pages/multiple-data-fetching.js
@@ -1,0 +1,6 @@
+export default function multipleDataFetching() {
+  return `/multiple-data-fetching`;
+}
+
+export async function getServerSideProps() {}
+multipleDataFetching.getInitialProps = function () {};

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -34,6 +34,7 @@ export type PageObject = {
   pagePath: string;
   params: PageParams;
   paramsNumber: number;
+  query: PageParams;
 };
 
 export type PageData =

--- a/src/fetchData.ts
+++ b/src/fetchData.ts
@@ -1,8 +1,41 @@
+import { Fragment } from 'react';
+import type {
+  NextPageContext,
+  GetServerSidePropsContext,
+  GetStaticPropsContext,
+} from 'next';
 import httpMocks from 'node-mocks-http';
-import type { Options, PageObject, PageData } from './commonTypes';
+import type {
+  Options,
+  PageObject,
+  PageData,
+  NextPageFile,
+} from './commonTypes';
+
+function ensureNoMultipleDataFetchingMethods({
+  page,
+}: {
+  page: NextPageFile;
+}): void {
+  let methodsCounter = 0;
+  if (page.getServerSideProps) {
+    methodsCounter++;
+  }
+  if (page.getStaticProps) {
+    methodsCounter++;
+  }
+  if (page.default.getInitialProps) {
+    methodsCounter++;
+  }
+  if (methodsCounter > 1) {
+    throw new Error(
+      '[next page tester] only one data fetching method is allowed'
+    );
+  }
+}
 
 export default async function fetchData({
-  pageObject: { page, params, route },
+  pageObject: { page, pagePath, params, route, query },
   reqMocker,
   resMocker,
 }: {
@@ -10,6 +43,29 @@ export default async function fetchData({
   reqMocker: Exclude<Options['req'], undefined>;
   resMocker: Exclude<Options['res'], undefined>;
 }): Promise<PageData> {
+  ensureNoMultipleDataFetchingMethods({ page });
+
+  if (page.default.getInitialProps) {
+    const req = httpMocks.createRequest({
+      url: route,
+      params: { ...params },
+    });
+
+    const ctx: NextPageContext = {
+      // @NOTE AppTree is currently just a stub
+      AppTree: Fragment,
+      req: reqMocker(req),
+      res: resMocker(httpMocks.createResponse()),
+      err: undefined,
+      pathname: pagePath,
+      query: { ...params, ...query }, // GIP ctx query merges params and query together
+      asPath: route,
+    };
+
+    const initialProps = await page.default.getInitialProps(ctx);
+    return { props: initialProps };
+  }
+
   if (page.getServerSideProps) {
     // @TODO complete ctx object
     // https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
@@ -18,21 +74,20 @@ export default async function fetchData({
       params: { ...params },
     });
 
-    const ctx = {
+    const ctx: GetServerSidePropsContext<typeof params> = {
       params: { ...params },
-      query: { ...req.query },
+      query: { ...query },
       req: reqMocker(req),
       res: resMocker(httpMocks.createResponse()),
     };
 
-    // @ts-ignore: Types of property 'req' are incompatible
     return await page.getServerSideProps(ctx);
   }
 
   if (page.getStaticProps) {
     // @TODO complete ctx object
     // https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
-    const ctx = {
+    const ctx: GetStaticPropsContext<typeof params> = {
       params: { ...params },
     };
     // @TODO introduce `getStaticPaths` logic

--- a/src/getPageObject.ts
+++ b/src/getPageObject.ts
@@ -1,7 +1,7 @@
 import getPagePaths from './getPagePaths';
 import pagePathToRouteRegex from './pagePathToRouteRegex';
 import loadPage from './loadPage';
-import { parseRoute } from './utils';
+import { parseRoute, parseQueryString } from './utils';
 import type { Options, PageObject, PageParams } from './commonTypes';
 
 export default async function getPageObject({
@@ -45,12 +45,12 @@ function makeParamsObject({
 
 type PageInfo = Pick<
   PageObject,
-  'route' | 'pagePath' | 'params' | 'paramsNumber'
+  'route' | 'pagePath' | 'params' | 'paramsNumber' | 'query'
 >;
 async function getPageInfo({ pagesDirectory, route }: Options) {
   const pagePaths = await getPagePaths({ pagesDirectory });
   const pagePathRegexes = pagePaths.map(pagePathToRouteRegex);
-  const routePathName = parseRoute({ route }).pathname;
+  const { pathname: routePathName, search } = parseRoute({ route });
 
   // Match provided route through route regexes generated from /page components
   const matchingPagePaths = pagePaths
@@ -65,6 +65,7 @@ async function getPageInfo({ pagesDirectory, route }: Options) {
           pagePath: originalPath,
           params,
           paramsNumber: Object.keys(params).length,
+          query: parseQueryString({ queryString: search }),
         };
       }
     })

--- a/src/makeRouterObject.ts
+++ b/src/makeRouterObject.ts
@@ -1,8 +1,8 @@
-import { removeFileExtension, parseQueryString, parseRoute } from './utils';
+import { removeFileExtension, parseRoute } from './utils';
 import type { PageObject } from './commonTypes';
 
 export default function makeRouterObject({
-  pageObject: { pagePath, params, route },
+  pageObject: { pagePath, params, route, query },
 }: {
   pageObject: PageObject;
 }) {
@@ -10,7 +10,7 @@ export default function makeRouterObject({
   return {
     asPath: pathname + search + hash, // Includes querystring and anchor
     pathname: removeFileExtension({ path: pagePath }), // Page component path without extension
-    query: { ...params, ...parseQueryString({ queryString: search }) }, // Route params + parsed querystring
+    query: { ...params, ...query }, // Route params + parsed querystring
     route: removeFileExtension({ path: pagePath }), // Page component path without extension
   };
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

[`getInitialProps`](https://nextjs.org/docs/api-reference/data-fetching/getInitialProps) data fetching method not supported

You can also link to an open issue here.

## What is the new behaviour?

Extend data fetching to support `getInitialProps`.

## Does this PR introduce a breaking change?

Yes.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [] Docs have been added / updated
