### PR TITLE
Support new fetching method result types

### DIFF
--- a/src/__tests__/__fixtures__/pages/ssr/not-found.js
+++ b/src/__tests__/__fixtures__/pages/ssr/not-found.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { sleep } from '../../../../utils';
+
+export default function ssr_notFound() {
+  return <>/ssr/not-found</>;
+}
+
+export async function getServerSideProps(ctx) {
+  await sleep(1);
+  return {
+    notFound: true,
+  };
+}

--- a/src/__tests__/__fixtures__/pages/ssr/redirect.js
+++ b/src/__tests__/__fixtures__/pages/ssr/redirect.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { sleep } from '../../../../utils';
+
+export default function ssr_notFound() {
+  return <>/ssr/redirect</>;
+}
+
+export async function getServerSideProps(ctx) {
+  await sleep(1);
+  return {
+    redirect: {
+      destination: '/another-page',
+      permanent: false,
+    },
+  };
+}

--- a/src/__tests__/page-data-fetching-special-returns.test.tsx
+++ b/src/__tests__/page-data-fetching-special-returns.test.tsx
@@ -1,0 +1,40 @@
+import '@testing-library/jest-dom';
+import type { CustomError } from '../commonTypes';
+import { getPage } from '../index';
+import * as RedirectPage from './__fixtures__/pages/ssr/redirect';
+import * as NotFoundPage from './__fixtures__/pages/ssr/not-found';
+const nextRoot = __dirname + '/__fixtures__';
+
+describe('Data fetching with special return types', () => {
+  describe('page with notFound', () => {
+    it('throws "missing prop field" error when redirect object is returned', async () => {
+      const returnObject = await NotFoundPage.getServerSideProps();
+      const expectedError: CustomError = new Error(
+        `[next page tester] Page's fetching method returned an object with missing "props" field. Returned value is available in error.payload.`
+      );
+      expectedError.payload = returnObject;
+
+      await expect(
+        getPage({
+          nextRoot,
+          route: '/ssr/not-found',
+        })
+      ).rejects.toThrow(expectedError);
+    });
+
+    it('throws "missing prop field" error when redirect object is returned', async () => {
+      const returnObject = await RedirectPage.getServerSideProps();
+      const expectedError: CustomError = new Error(
+        `[next page tester] Page's fetching method returned an object with missing "props" field. Returned value is available in error.payload.`
+      );
+      expectedError.payload = returnObject;
+
+      await expect(
+        getPage({
+          nextRoot,
+          route: '/ssr/redirect',
+        })
+      ).rejects.toThrow(expectedError);
+    });
+  });
+});

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -63,3 +63,7 @@ export type PageData = {
     [key: string]: any;
   };
 };
+
+export class CustomError extends Error {
+  payload?: any;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Breaking change

## What is the current behaviour?

Currently no return type check is performed against pages' fetching method result. Since Next.js v10 introduced `notFound` and `redirect` return types, we need a way to tell normal `prop` returns from the others.

## What is the new behaviour?

Throw error when fetching methods return object with missing props field. Object returned by fetching method is made available in `error.payload`.

## Does this PR introduce a breaking change?

Yes. Users should handle throws error in case fetching method returns object with missing `props` field.

## Other information:

https://nextjs.org/blog/next-10#redirect-and-notfound-support-for-getstaticprops--getserversideprops

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
