### PR TITLE
Auto-detect pageExtensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,14 @@ Next page tester will take care of:
 
 ## Options
 
-| Property              | Description                                                                      | type               | Default                             |
-| --------------------- | -------------------------------------------------------------------------------- | ------------------ | ----------------------------------- |
-| **route** (mandatory) | Next route (must start with `/`)                                                 | `string`           | -                                   |
-| **req**               | Access default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -                                   |
-| **res**               | Access default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -                                   |
-| **router**            | Access default mocked [Next router object][next-docs-router]                     | `router => router` | -                                   |
-| **customApp**         | Use [custom App component][next-docs-custom-app]                                 | `boolean`          | `false`                             |
-| **nextRoot**          | Absolute path to Next's root folder                                              | `string`           | _auto detected_                     |
-| **pageExtensions**    | [Custom Page Extensions][next-docs-custom-page-extensions]                       | `string[]`         | `['mdx', 'jsx', 'js', 'ts', 'tsx']` |
+| Property              | Description                                                                      | type               | Default         |
+| --------------------- | -------------------------------------------------------------------------------- | ------------------ | --------------- |
+| **route** (mandatory) | Next route (must start with `/`)                                                 | `string`           | -               |
+| **req**               | Access default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -               |
+| **res**               | Access default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -               |
+| **router**            | Access default mocked [Next router object][next-docs-router]                     | `router => router` | -               |
+| **customApp**         | Use [custom App component][next-docs-custom-app]                                 | `boolean`          | `false`         |
+| **nextRoot**          | Absolute path to Next's root folder                                              | `string`           | _auto detected_ |
 
 ## Notes
 
@@ -62,7 +61,6 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 
 - Consider adding custom Document support
 - Consider reusing Next.js code parts (not only types)
-- Consider loading `pageExtensions` option from `next.config.js`
 
 [ci]: https://travis-ci.com/toomuchdesign/next-page-tester
 [ci-badge]: https://travis-ci.com/toomuchdesign/next-page-tester.svg?branch=master
@@ -78,5 +76,4 @@ It might be necessary to install `@types/react-dom` and `@types/webpack` when us
 [next-docs-data-fetching]: https://nextjs.org/docs/basic-features/data-fetching
 [next-docs-router]: https://nextjs.org/docs/api-reference/next/router
 [next-docs-custom-app]: https://nextjs.org/docs/advanced-features/custom-app
-[next-docs-custom-page-extensions]: https://nextjs.org/docs/api-reference/next.config.js/custom-page-extensions
 [next-gh-strict-bug]: https://github.com/vercel/next.js/issues/16219

--- a/src/__tests__/custom-app/__fixtures__/special-extension/next.config.js
+++ b/src/__tests__/custom-app/__fixtures__/special-extension/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['tsx', 'ts', 'jsx', 'js'],
+};

--- a/src/__tests__/custom-app/custom-app.test.tsx
+++ b/src/__tests__/custom-app/custom-app.test.tsx
@@ -128,7 +128,7 @@ describe('Custom App component', () => {
     });
   });
 
-  it('Loads custom app file with any extension defined in "pageExtensions" option', async () => {
+  it('Loads custom app file with any extension defined in "next.config.js"', async () => {
     const actualPage = await getPage({
       nextRoot: __dirname + '/__fixtures__/special-extension',
       route: '/page',

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -17,7 +17,6 @@ export type Options = {
   res?: (res: Res) => Res;
   router?: (router: NextRouter) => NextRouter;
   customApp?: boolean;
-  pageExtensions?: string[];
 };
 
 export type OptionsWithDefaults = Required<Options>;
@@ -25,6 +24,7 @@ export type OptionsWithDefaults = Required<Options>;
 // Options object is extended with some extra derived props
 export type ExtendedOptions = OptionsWithDefaults & {
   pagesDirectory: string;
+  pageExtensions: string[];
 };
 
 export type NextPageFile = {

--- a/src/getPage.ts
+++ b/src/getPage.ts
@@ -3,7 +3,11 @@ import getPageObject from './getPageObject';
 import getCustomAppFile from './getCustomAppFile';
 import { fetchAppData, fetchPageData } from './fetchData';
 import preparePage from './preparePage';
-import { defaultNextRoot, findPagesDirectory } from './utils';
+import {
+  defaultNextRoot,
+  findPagesDirectory,
+  getPageExtensions,
+} from './utils';
 import type {
   Options,
   OptionsWithDefaults,
@@ -29,7 +33,6 @@ export default async function getPage({
   res = (res) => res,
   router = (router) => router,
   customApp = false,
-  pageExtensions = ['mdx', 'jsx', 'js', 'ts', 'tsx'],
 }: Options): Promise<React.ReactElement> {
   const optionsWithDefaults: OptionsWithDefaults = {
     route,
@@ -38,14 +41,16 @@ export default async function getPage({
     res,
     router,
     customApp,
-    pageExtensions,
   };
   validateOptions(optionsWithDefaults);
 
   const options: ExtendedOptions = {
     ...optionsWithDefaults,
     pagesDirectory: findPagesDirectory({ nextRoot }),
+    pageExtensions: getPageExtensions({ nextRoot }),
   };
+
+  // @TODO: Consider printing extended options value behind a debug flag
 
   const pageObject = await getPageObject({ options });
   if (pageObject === undefined) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,8 @@ import { URL } from 'url';
 import querystring from 'querystring';
 import findRoot from 'find-root';
 import { existsSync } from 'fs';
+import loadConfig from 'next/dist/next-server/server/config';
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 
 export function parseRoute({ route }: { route: string }) {
   return new URL(`http://test.com${route}`);
@@ -42,4 +44,25 @@ export function findPagesDirectory({ nextRoot }: { nextRoot: string }) {
   throw new Error(
     `[next page tester] cannot find "pages" directory under: ${nextRoot}`
   );
+}
+
+/*
+ * Retrieve Next.js config using Next.js internals
+ * https://github.com/vercel/next.js/blob/v10.0.1/test/isolated/config.test.js#L12
+ *
+ * Default config:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config.ts
+ */
+function getNextConfig({ pathToConfig }: { pathToConfig: string }) {
+  return loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig);
+}
+
+export function getPageExtensions({
+  nextRoot,
+}: {
+  nextRoot: string;
+}): string[] {
+  const config = getNextConfig({ pathToConfig: nextRoot });
+  const { pageExtensions } = config as { pageExtensions: string[] };
+  return pageExtensions;
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Next.js `pageExtensions` config option has to be explicitly declared as `getPage` option.

## What is the new behaviour?

Retrieve `pageExtensions` option from `next.config.js` + defaults using Next.js internals.

## Does this PR introduce a breaking change?

Yes. `pageExtensions` option is removed. A change in `next.config.js/pageExtensions` option is reflected in `next-page-tester` runtime.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
