### PR TITLE
Fix default routing behaviour with trailing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Next.js `Link` components invoke `window.scrollTo` on click which is not impleme
 
 - Consider adding custom Document support
 - Consider reusing Next.js code parts (not only types)
+- Consider supporting Next.js `trailingSlash` option
 
 [ci]: https://travis-ci.com/toomuchdesign/next-page-tester
 [ci-badge]: https://travis-ci.com/toomuchdesign/next-page-tester.svg?branch=master

--- a/src/__tests__/pagePathToRegex.test.ts
+++ b/src/__tests__/pagePathToRegex.test.ts
@@ -4,7 +4,7 @@ describe('pagePathToRouteRegex', () => {
   describe('predefined routes', () => {
     it('gets expected regex', () => {
       const actual = pagePathToRouteRegex('/index');
-      const expected = new RegExp('^(?:/index)?$').toString();
+      const expected = new RegExp('^/(?:index)?$').toString();
       expect(actual.toString()).toBe(expected);
     });
   });

--- a/src/__tests__/routing-static-routes.test.tsx
+++ b/src/__tests__/routing-static-routes.test.tsx
@@ -48,7 +48,7 @@ describe('Static routes', () => {
   });
 
   describe('page file extensions', () => {
-    describe('declared in "pageExtensions" config', () => {
+    describe('extension declared in "pageExtensions" config', () => {
       it('renders page', async () => {
         const actualPage = await getPage({
           nextRoot,
@@ -60,7 +60,7 @@ describe('Static routes', () => {
       });
     });
 
-    describe('NOT declared in "pageExtensions" config', () => {
+    describe('extension NOT declared in "pageExtensions" config', () => {
       it('throws "page not found" error', async () => {
         await expect(
           getPage({

--- a/src/__tests__/routing-static-routes.test.tsx
+++ b/src/__tests__/routing-static-routes.test.tsx
@@ -31,10 +31,11 @@ describe('Static routes', () => {
   });
 
   describe('route with trailing slash', () => {
-    it('throws "page not found" error', async () => {
-      await expect(getPage({ nextRoot, route: '/blog/5/' })).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
-      );
+    it('redirect to their counterpart without a trailing slash', async () => {
+      const actualPage = await getPage({ nextRoot, route: '/blog/' });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<BlogIndexPage />);
+      expect(actual).toEqual(expected);
     });
   });
 
@@ -46,36 +47,45 @@ describe('Static routes', () => {
     });
   });
 
-  describe('route matching page with valid non ".js" extension', () => {
-    it('renders page', async () => {
-      const actualPage = await getPage({
-        nextRoot,
-        route: '/typescript',
-      });
-      const { container: actual } = render(actualPage);
-      const { container: expected } = render(<TypescriptPage />);
-      expect(actual).toEqual(expected);
-    });
-  });
-
-  describe('route matching page file with invalid extension', () => {
-    it('throws "page not found" error', async () => {
-      await expect(
-        getPage({
+  describe('page file extensions', () => {
+    describe('declared in "pageExtensions" config', () => {
+      it('renders page', async () => {
+        const actualPage = await getPage({
           nextRoot,
-          route: '/invalid-extension',
-        })
-      ).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
-      );
+          route: '/typescript',
+        });
+        const { container: actual } = render(actualPage);
+        const { container: expected } = render(<TypescriptPage />);
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    describe('NOT declared in "pageExtensions" config', () => {
+      it('throws "page not found" error', async () => {
+        await expect(
+          getPage({
+            nextRoot,
+            route: '/invalid-extension',
+          })
+        ).rejects.toThrow(
+          '[next page tester] No matching page found for given route'
+        );
+      });
     });
   });
 
-  describe('Index routes', () => {
-    it('route files named index to the root of the directory', async () => {
+  describe('index routes', () => {
+    it('routes files named index to the root of the directory', async () => {
       const actualPage = await getPage({ nextRoot, route: '/blog' });
       const { container: actual } = render(actualPage);
       const { container: expected } = render(<BlogIndexPage />);
+      expect(actual).toEqual(expected);
+    });
+
+    it('routes root pages/index page to "/"', async () => {
+      const actualPage = await getPage({ nextRoot, route: '/' });
+      const { container: actual } = render(actualPage);
+      const { container: expected } = render(<IndexPage />);
       expect(actual).toEqual(expected);
     });
   });

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -7,6 +7,7 @@ import type {
 import { AppContext, AppInitialProps } from 'next/app';
 import type { NextRouter } from 'next/router';
 import type { createRequest, createResponse } from 'node-mocks-http';
+import type { ParsedUrlQuery } from 'querystring';
 type Req = ReturnType<typeof createRequest>;
 type Res = ReturnType<typeof createResponse>;
 
@@ -47,7 +48,7 @@ export type NextCustomAppFile = {
   };
 };
 
-export type PageParams = { [name: string]: string | string[] };
+export type PageParams = ParsedUrlQuery;
 
 export type PageObject = {
   page: NextPageFile;

--- a/src/getPageObject.ts
+++ b/src/getPageObject.ts
@@ -52,12 +52,12 @@ type PageInfo = Pick<
 >;
 async function getPageInfo({ options }: { options: ExtendedOptions }) {
   const { route } = options;
+  const { pathname: routePathName, search } = parseRoute({ route });
   const pagePaths = await getPagePaths({ options });
   const pagePathRegexes = pagePaths.map(pagePathToRouteRegex);
-  const { pathname: routePathName, search } = parseRoute({ route });
 
   // Match provided route through route regexes generated from /page components
-  const matchingPagePaths = pagePaths
+  const matchingPageInfo: PageInfo[] = pagePaths
     .map((originalPath, index) => {
       const result = routePathName.match(pagePathRegexes[index]);
       if (result) {
@@ -77,5 +77,5 @@ async function getPageInfo({ options }: { options: ExtendedOptions }) {
     .sort((a, b) => a.paramsNumber - b.paramsNumber);
 
   // Return the result with less page params
-  return matchingPagePaths[0];
+  return matchingPageInfo[0];
 }

--- a/src/pagePathToRouteRegex.ts
+++ b/src/pagePathToRouteRegex.ts
@@ -29,6 +29,11 @@ function makeOptionalNamedCapturingGroup({ name, regex }: namedCapture) {
 
 // Build a regex from a page path to catch its matching routes
 function pagePathToRouteRegex(pagePath: string): RegExp {
+  // Special case for /index page which should match both "/" and "/index" pathnames
+  if (pagePath === '/index') {
+    return /^\/(?:index)?$/;
+  }
+
   const regex = pagePath
     .replace(TRAILING_INDEX_REGEX, OPTIONAL_TRAILING_INDEX_REGEX_STRING)
     .replace(OPTIONAL_CATCH_ALL_ROUTE_SEGMENT_REGEX, (match, paramName) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,9 +9,12 @@ import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
   let { pathname } = urlObject;
-
-  // @NOTE Here we might handle Next.js trailingSlash option
-  // https://nextjs.org/docs/api-reference/next.config.js/trailing-slash
+  
+  /*
+   * Next.js redirects by default routes with trailing slash to the counterpart without trailing slash
+   * @NOTE: Here we might handle Next.js trailingSlash option
+   * https://nextjs.org/docs/api-reference/next.config.js/trailing-slash
+   */
   if (pathname.endsWith('/') && pathname !== '/') {
     urlObject.pathname = pathname.slice(0, -1);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,10 +7,23 @@ import loadConfig from 'next/dist/next-server/server/config';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 
 export function parseRoute({ route }: { route: string }) {
-  return new URL(`http://test.com${route}`);
+  const urlObject = new URL(`http://test.com${route}`);
+  let { pathname } = urlObject;
+
+  // @NOTE Here we might handle Next.js trailingSlash option
+  // https://nextjs.org/docs/api-reference/next.config.js/trailing-slash
+  if (pathname.endsWith('/') && pathname !== '/') {
+    urlObject.pathname = pathname.slice(0, -1);
+  }
+
+  return urlObject;
 }
 
-export function parseQueryString({ queryString }: { queryString: string }) {
+export function parseQueryString({
+  queryString,
+}: {
+  queryString: string;
+}): querystring.ParsedUrlQuery {
   const qs = queryString.startsWith('?')
     ? queryString.substring(1)
     : queryString;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

1. #22 
2. routes with trailing slash like `blog/5/` return "not found error"

## What is the new behaviour?

1. `/` and `/index` route to `pages/index/` as expected.
2. routes with trailing slash like `blog/5/` redirect to their counterpart without slash (`blog/5`)

Further routes with trailing slash

## Does this PR introduce a breaking change?

Yes, if the tests involved the routes types covered by this PR.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
