### PR TITLE
Return an object with page property

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ import { getPage } from 'next-page-tester';
 
 describe('Blog page', () => {
   it('renders blog page', async () => {
-    const Page = await getPage({
+    const { page } = await getPage({
       route: '/blog/1',
     });
 
-    render(Page);
+    render(page);
     expect(screen.getByText('Blog')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('Link'));

--- a/src/__tests__/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation.test.tsx
@@ -12,11 +12,11 @@ describe('Client side navigation', () => {
     ${'programmatically'}     | ${'Go to B programmatically'}
   `('$title', ({ linkText }) => {
     it('navigates between pages', async () => {
-      const Page = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/client-navigation-link/a',
       });
-      const screen = render(Page);
+      const screen = render(page);
       screen.getByText('This is page A');
 
       // Navigate A -> B
@@ -45,11 +45,11 @@ describe('Client side navigation', () => {
   // @ NOTE This test doesn't actually fail
   // but it forces Jest to render errors about updates after unmount in console
   it('does not re-render (does not update router mock) if page gets unmounted', async () => {
-    const Page = await getPage({
+    const { page } = await getPage({
       nextRoot,
       route: '/client-navigation-link/a',
     });
-    const { unmount } = render(Page);
+    const { unmount } = render(page);
     const linkToB = screen.getByText('Go to B with Link');
     fireEvent.click(linkToB);
     unmount();

--- a/src/__tests__/custom-app/custom-app.test.tsx
+++ b/src/__tests__/custom-app/custom-app.test.tsx
@@ -19,12 +19,12 @@ import MissingCustomAppPage from './__fixtures__/missing-custom-app/pages/page';
 describe('Custom App component', () => {
   describe('with getInitialProps', () => {
     it('getInitialProps gets called with expected appContext', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route: '/app-context',
         useCustomApp: true,
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const expectedAppContext = {
         AppTree: Fragment,
         Component: CustomAppWithGIP_AppContextPage,
@@ -63,12 +63,12 @@ describe('Custom App component', () => {
       ['getServerSideProps', '/ssr', CustomAppWithGIP_SSRPage],
       ['getStaticProps', '/ssg', CustomAppWithGIP_SSGPage],
     ])('Page with %s', async (dataFetchingType, route, PageComponent) => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route,
         useCustomApp: true,
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <CustomAppWithGIP
           Component={PageComponent}
@@ -85,12 +85,12 @@ describe('Custom App component', () => {
 
     describe('Page with getInitialProps', () => {
       it('getInitialProps does not get called', async () => {
-        const actualPage = await getPage({
+        const { page } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
           route: '/gip',
           useCustomApp: true,
         });
-        const { container: actual } = render(actualPage);
+        const { container: actual } = render(page);
         const { container: expected } = render(
           <CustomAppWithGIP
             Component={CustomAppWithGIP_GIPPage}
@@ -108,13 +108,13 @@ describe('Custom App component', () => {
   describe("calling Next's App.getInitialProps", () => {
     describe('Page with getInitialProps', () => {
       it("App.getInitialProps is able to call page's getInitialProps", async () => {
-        const actualPage = await getPage({
+        const { page } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-next-app-gip',
           route: '/gip',
           useCustomApp: true,
         });
 
-        const { container: actual } = render(actualPage);
+        const { container: actual } = render(page);
         const { container: expected } = render(
           <CustomAppWithNextAppGIP
             Component={CustomAppWithNextAppGIP_GIP}
@@ -129,12 +129,12 @@ describe('Custom App component', () => {
   });
 
   it('Loads custom app file with any extension defined in "next.config.js"', async () => {
-    const actualPage = await getPage({
+    const { page } = await getPage({
       nextRoot: __dirname + '/__fixtures__/special-extension',
       route: '/page',
       useCustomApp: true,
     });
-    const { container: actual } = render(actualPage);
+    const { container: actual } = render(page);
     const { container: expected } = render(
       <SpecialExtensionCustomApp Component={SpecialExtensionPage} />
     );
@@ -142,12 +142,12 @@ describe('Custom App component', () => {
   });
 
   it('Return page as usual if no custom app file is found', async () => {
-    const actualPage = await getPage({
+    const { page } = await getPage({
       nextRoot: __dirname + '/__fixtures__/missing-custom-app',
       route: '/page',
       useCustomApp: true,
     });
-    const { container: actual } = render(actualPage);
+    const { container: actual } = render(page);
     const { container: expected } = render(<MissingCustomAppPage />);
     expect(actual).toEqual(expected);
   });

--- a/src/__tests__/page-data-fetching.test.tsx
+++ b/src/__tests__/page-data-fetching.test.tsx
@@ -11,7 +11,7 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Data fetching', () => {
   describe('page with getInitialProps', () => {
     it('feeds page component with returned props', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/gip/5?foo=bar',
       });
@@ -19,7 +19,7 @@ describe('Data fetching', () => {
       const expectedParams = { id: '5' };
       const expectedQuery = { foo: 'bar' };
 
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const expectedContext = {
         AppTree: Fragment,
         req: httpMocks.createRequest({
@@ -41,7 +41,7 @@ describe('Data fetching', () => {
 
   describe('page with getServerSideProps', () => {
     it('feeds page component with returned props', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/ssr/5?foo=bar',
       });
@@ -49,7 +49,7 @@ describe('Data fetching', () => {
       const expectedParams = { id: '5' };
       const expectedQuery = { foo: 'bar' };
 
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const expectedContext = {
         params: expectedParams,
         query: expectedQuery,
@@ -68,11 +68,11 @@ describe('Data fetching', () => {
 
   describe('page with getStaticProps', () => {
     it('feeds page component with returned props', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/ssg/5?foo=bar',
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <SSGPage
           params={{

--- a/src/__tests__/pages-discovery/pages-discovery.test.js
+++ b/src/__tests__/pages-discovery/pages-discovery.test.js
@@ -9,11 +9,11 @@ import { getPage } from '../../index';
 
 describe('Pages directory discovery + "nextRoot" option', () => {
   it('discover "pages" directory in auto-detected root', async () => {
-    const actualPage = await getPage({
+    const { page } = await getPage({
       route: '/page',
     });
 
-    const { container: actual } = render(actualPage);
+    const { container: actual } = render(page);
     const { container: expected } = render(<PageInNaturalRoot />);
     expect(actual).toEqual(expected);
   });
@@ -21,24 +21,24 @@ describe('Pages directory discovery + "nextRoot" option', () => {
   describe('With "nextRoot" option', () => {
     it('discover "pages" directory in provided root', async () => {
       const nextRoot = path.join(__dirname, '/in-root');
-      const actualPage = await getPage({
+      const { page } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(<PageInRoot />);
       expect(actual).toEqual(expected);
     });
 
     it('discover "pages" directory in root/src', async () => {
       const nextRoot = path.join(__dirname, '/in-src');
-      const actualPage = await getPage({
+      const { page } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(<PageInSrc />);
       expect(actual).toEqual(expected);
     });

--- a/src/__tests__/router-mocking.test.tsx
+++ b/src/__tests__/router-mocking.test.tsx
@@ -8,12 +8,12 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Router mocking', () => {
   describe('page using "useRouter"', () => {
     it('receives expected router object', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/with-router/99?foo=bar#moo',
       });
 
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <WithRouter
           routerMock={{
@@ -37,13 +37,13 @@ describe('Router mocking', () => {
       const routerMock = {
         route: 'mocked',
       };
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/with-router/99',
         // @ts-ignore
         router: (router) => routerMock,
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <WithRouter routerMock={routerMock} />
       );

--- a/src/__tests__/routing-dynamic-routes.test.tsx
+++ b/src/__tests__/routing-dynamic-routes.test.tsx
@@ -6,17 +6,16 @@ import BlogPage from './__fixtures__/pages/blog/[id]';
 import BlogPage99 from './__fixtures__/pages/blog/99';
 import CatchAllPage from './__fixtures__/pages/catch-all/[id]/[...slug]';
 import OptionalCatchAllPage from './__fixtures__/pages/optional-catch-all/[id]/[[...slug]]';
-import { sleep } from './__utils__';
 const nextRoot = __dirname + '/__fixtures__';
 
 describe('Dynamic routes', () => {
   describe('Basic dynamic routes', () => {
     it('gets expected page object', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/blog/5',
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <BlogPage
           routerMock={{
@@ -30,11 +29,11 @@ describe('Dynamic routes', () => {
     });
 
     it('gets expected page object with params and querystring', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/blog/5?foo=bar',
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <BlogPage
           routerMock={{
@@ -49,11 +48,11 @@ describe('Dynamic routes', () => {
     });
 
     it('predefined routes take precedence over dynamic', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/blog/99',
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(<BlogPage99 />);
       expect(actual).toEqual(expected);
     });
@@ -61,11 +60,11 @@ describe('Dynamic routes', () => {
 
   describe('Catch all routes', () => {
     it('gets expected page object with params and querystring', async () => {
-      const actualPage = await getPage({
+      const { page } = await getPage({
         nextRoot,
         route: '/catch-all/5/foo/bar/moo?foo=bar',
       });
-      const { container: actual } = render(actualPage);
+      const { container: actual } = render(page);
       const { container: expected } = render(
         <CatchAllPage
           routerMock={{
@@ -95,11 +94,11 @@ describe('Dynamic routes', () => {
   describe('Optional catch all routes', () => {
     describe('Optional catch all routes', () => {
       it('gets expected page object with params and querystring', async () => {
-        const actualPage = await getPage({
+        const { page } = await getPage({
           nextRoot,
           route: '/optional-catch-all/5/foo/bar/moo?foo=bar',
         });
-        const { container: actual } = render(actualPage);
+        const { container: actual } = render(page);
         const { container: expected } = render(
           <OptionalCatchAllPage
             routerMock={{
@@ -115,11 +114,11 @@ describe('Dynamic routes', () => {
       });
 
       it('matches when no optional params are provided', async () => {
-        const actualPage = await getPage({
+        const { page } = await getPage({
           nextRoot,
           route: '/optional-catch-all/5',
         });
-        const { container: actual } = render(actualPage);
+        const { container: actual } = render(page);
         const { container: expected } = render(
           <OptionalCatchAllPage
             routerMock={{

--- a/src/__tests__/routing-static-routes.test.tsx
+++ b/src/__tests__/routing-static-routes.test.tsx
@@ -10,8 +10,8 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Static routes', () => {
   describe('route matching a page path', () => {
     it('gets expected component', async () => {
-      const actualPage = await getPage({ nextRoot, route: '/index' });
-      const { container: actual } = render(actualPage);
+      const { page } = await getPage({ nextRoot, route: '/index' });
+      const { container: actual } = render(page);
       const { container: expected } = render(<IndexPage />);
       expect(actual).toEqual(expected);
     });
@@ -32,8 +32,8 @@ describe('Static routes', () => {
 
   describe('route with trailing slash', () => {
     it('redirect to their counterpart without a trailing slash', async () => {
-      const actualPage = await getPage({ nextRoot, route: '/blog/' });
-      const { container: actual } = render(actualPage);
+      const { page } = await getPage({ nextRoot, route: '/blog/' });
+      const { container: actual } = render(page);
       const { container: expected } = render(<BlogIndexPage />);
       expect(actual).toEqual(expected);
     });
@@ -50,11 +50,11 @@ describe('Static routes', () => {
   describe('page file extensions', () => {
     describe('extension declared in "pageExtensions" config', () => {
       it('renders page', async () => {
-        const actualPage = await getPage({
+        const { page } = await getPage({
           nextRoot,
           route: '/typescript',
         });
-        const { container: actual } = render(actualPage);
+        const { container: actual } = render(page);
         const { container: expected } = render(<TypescriptPage />);
         expect(actual).toEqual(expected);
       });
@@ -76,15 +76,15 @@ describe('Static routes', () => {
 
   describe('index routes', () => {
     it('routes files named index to the root of the directory', async () => {
-      const actualPage = await getPage({ nextRoot, route: '/blog' });
-      const { container: actual } = render(actualPage);
+      const { page } = await getPage({ nextRoot, route: '/blog' });
+      const { container: actual } = render(page);
       const { container: expected } = render(<BlogIndexPage />);
       expect(actual).toEqual(expected);
     });
 
     it('routes root pages/index page to "/"', async () => {
-      const actualPage = await getPage({ nextRoot, route: '/' });
-      const { container: actual } = render(actualPage);
+      const { page } = await getPage({ nextRoot, route: '/' });
+      const { container: actual } = render(page);
       const { container: expected } = render(<IndexPage />);
       expect(actual).toEqual(expected);
     });

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -34,7 +34,7 @@ export default async function getPage({
   res = (res) => res,
   router = (router) => router,
   useCustomApp = false,
-}: Options): Promise<React.ReactElement> {
+}: Options): Promise<{ page: React.ReactElement }> {
   const optionsWithDefaults: OptionsWithDefaults = {
     route,
     nextRoot,
@@ -70,16 +70,18 @@ export default async function getPage({
 
   const { pageElement, pageObject } = await makePage();
 
-  return (
-    <RouterProvider pageObject={pageObject} options={options}>
-      <NavigationProvider
-        makePage={async (route) => {
-          const { pageElement } = await makePage(route);
-          return pageElement;
-        }}
-      >
-        {pageElement}
-      </NavigationProvider>
-    </RouterProvider>
-  );
+  return {
+    page: (
+      <RouterProvider pageObject={pageObject} options={options}>
+        <NavigationProvider
+          makePage={async (route) => {
+            const { pageElement } = await makePage(route);
+            return pageElement;
+          }}
+        >
+          {pageElement}
+        </NavigationProvider>
+      </RouterProvider>
+    ),
+  };
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

`getPage` returns the page element, preventing method from returning additional info.

## What is the new behaviour?

`getPage` returns an object with a `page` field holding the page element. The returning object will possibly be extended with additional info.

## Does this PR introduce a breaking change?

Yes:

```js
const myPage = getPage({ route: '/my-route' });
```
...becomes
```js
const { page: myPage } = getPage({ route: '/my-route' });
```

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
