### PR TITLE
Default useCustomApp option to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Next page tester will take care of:
 | **req**               | Access default mocked [request object][req-docs]<br>(`getServerSideProps` only)  | `res => res`       | -               |
 | **res**               | Access default mocked [response object][res-docs]<br>(`getServerSideProps` only) | `req => req`       | -               |
 | **router**            | Access default mocked [Next router object][next-docs-router]                     | `router => router` | -               |
-| **useCustomApp**      | Use [custom App component][next-docs-custom-app]                                 | `boolean`          | `false`         |
+| **useCustomApp**      | Use [custom App component][next-docs-custom-app]                                 | `boolean`          | `true`          |
 | **nextRoot**          | Absolute path to Next's root folder                                              | `string`           | _auto detected_ |
 
 ## Notes

--- a/src/__tests__/custom-app/custom-app.test.tsx
+++ b/src/__tests__/custom-app/custom-app.test.tsx
@@ -22,7 +22,6 @@ describe('Custom App component', () => {
       const { page } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route: '/app-context',
-        useCustomApp: true,
       });
       const { container: actual } = render(page);
       const expectedAppContext = {
@@ -66,7 +65,6 @@ describe('Custom App component', () => {
       const { page } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route,
-        useCustomApp: true,
       });
       const { container: actual } = render(page);
       const { container: expected } = render(
@@ -88,7 +86,6 @@ describe('Custom App component', () => {
         const { page } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
           route: '/gip',
-          useCustomApp: true,
         });
         const { container: actual } = render(page);
         const { container: expected } = render(
@@ -111,7 +108,6 @@ describe('Custom App component', () => {
         const { page } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-next-app-gip',
           route: '/gip',
-          useCustomApp: true,
         });
 
         const { container: actual } = render(page);
@@ -132,7 +128,6 @@ describe('Custom App component', () => {
     const { page } = await getPage({
       nextRoot: __dirname + '/__fixtures__/special-extension',
       route: '/page',
-      useCustomApp: true,
     });
     const { container: actual } = render(page);
     const { container: expected } = render(
@@ -145,7 +140,6 @@ describe('Custom App component', () => {
     const { page } = await getPage({
       nextRoot: __dirname + '/__fixtures__/missing-custom-app',
       route: '/page',
-      useCustomApp: true,
     });
     const { container: actual } = render(page);
     const { container: expected } = render(<MissingCustomAppPage />);
@@ -158,11 +152,23 @@ describe('Custom App component', () => {
         getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
           route: '/_app',
-          useCustomApp: true,
         })
       ).rejects.toThrow(
         '[next page tester] No matching page found for given route'
       );
+    });
+  });
+
+  describe('"useCustomApp" === false while _app component available', () => {
+    it('does not render custom App', async () => {
+      const { page } = await getPage({
+        nextRoot: __dirname + '/__fixtures__/special-extension',
+        route: '/page',
+        useCustomApp: false,
+      });
+      const { container: actual } = render(page);
+      const { container: expected } = render(<SpecialExtensionPage />);
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -33,7 +33,7 @@ export default async function getPage({
   req = (req) => req,
   res = (res) => res,
   router = (router) => router,
-  useCustomApp = false,
+  useCustomApp = true,
 }: Options): Promise<{ page: React.ReactElement }> {
   const optionsWithDefaults: OptionsWithDefaults = {
     route,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Options default change

## What is the current behaviour?

`useCustomApp` option defaults to `false`

## What is the new behaviour?

`useCustomApp` option defaults to `true`

## Does this PR introduce a breaking change?

Yes. Users should explicitly opt-out from custom app detection and rendering.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
