### PR TITLE
ci: don't explicitly trigger prepare script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: npm ci
-      - run: npm run prepare
 
       - name: Upload code coverage
         uses: coverallsapp/github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: npm ci
+        env:
+          HUSKY_SKIP_INSTALL: 1
 
       - name: Upload code coverage
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
## What kind of change does this PR introduce?

CI optimization

## What is the current behaviour?

`npm run pepare` executed twice in CI pipeline.

CI fires consecutively `npm run ci` and `npm run pepare`. But `npm run ci` calls automatically `npm run pepare` after dependencies are installed

## What is the new behaviour?

Call just `npm run ci`. 

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
