### PR TITLE
fix: next head query

### DIFF
--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -60,6 +60,19 @@ export default async function getPage({
 
   const headManager = useDocument && initHeadManager();
 
+  // For NextJS to correctly query <head> element we have to proxy its query through body (as this is where RTL will render the whole output to)
+  // to avoid "Warning: next-head-count is missing. https://err.sh/next.js/next-head-count-missing"
+  // https://github.com/vercel/next.js/blob/c96c13a71b61b93c87ed34f11ae7d37ede44eaec/packages/next/client/head-manager.ts#L36
+  const { getElementsByTagName } = document;
+  document.getElementsByTagName = function <K extends string>(this, tag: K) {
+    if (tag === 'head') {
+      return document.body.getElementsByTagName(tag);
+    }
+
+    document.getElementsByTagName = getElementsByTagName;
+    return this.getElementsByTagName(tag);
+  };
+
   const makePage = async (
     optionsOverride?: Partial<ExtendedOptions>
   ): Promise<{

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -35,12 +35,6 @@ export function initTestHelpers() {
 
   function setup() {
     if (isJSDOMEnvironment()) {
-      // Remove initial JSDOM <head> element
-      const headElement = document.querySelector('head');
-      if (headElement) {
-        headElement.remove();
-      }
-
       // Suppress validateDOMNesting error logs
       // we now we're doing borderline stuff like rendering nested html elements
       console.error = (error: string) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

NextJS incorrectly queried `head` element which would result in `Warning: next-head-count is missing. https://err.sh/next.js/next-head-count-missing` had we not hack it around

## What is the new behaviour?

Hack is not necessary anymore

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
