### PR TITLE
test: prevent console.warn from logging error

### DIFF
--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -104,8 +104,7 @@ describe('Client side navigation', () => {
   });
 
   it('does not re-render (does not update router mock) if page gets unmounted', async () => {
-    const warn = jest.spyOn(console, 'warn');
-
+    const warn = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     const { page } = await getPage({
       nextRoot,
       route: '/a',
@@ -120,5 +119,7 @@ describe('Client side navigation', () => {
         '[next-page-tester]: Un-awaited client side navigation. This might lead into unexpected bugs and errors.'
       );
     });
+
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test fix.

## What is the current behaviour?

'client-navigation' tests log warning during execution (triggering console.warn is part of the test itself, not a side effect).

## What is the new behaviour?

Temporarily mock `console.warn` to avoid error log.

## Does this PR introduce a breaking change?

No.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
