### PR TITLE
chore: log un-awaited navigation routes

### DIFF
--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -116,7 +116,7 @@ describe('Client side navigation', () => {
 
     await waitFor(() => {
       expect(warn).toHaveBeenCalledWith(
-        '[next-page-tester]: Un-awaited client side navigation. This might lead into unexpected bugs and errors.'
+        '[next-page-tester]: Un-awaited client side navigation from "/a" to "/b". This might lead into unexpected bugs and errors.'
       );
     });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Improvement

## What is the current behaviour?

Warning is logged on un-awaited client side navigation, but it lacks some additional information to make it easier to debug which transition the warning relates to (its hard to pinpoint the problem when jest is executing tests in parallel and logging all over the place)

## What is the new behaviour?

Previous and next route are included in the log

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
