### PR TITLE
feature: require pages in browser and non-browser environment

### DIFF
--- a/@types/stealthy-require/index.d.ts
+++ b/@types/stealthy-require/index.d.ts
@@ -1,0 +1,6 @@
+declare module 'stealthy-require' {
+  export default function stealthyRequire<Result>(
+    requireCache: typeof require.cache,
+    callback: () => Result
+  ): Result;
+}

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ import { initTestHelpers } from 'next-page-tester';
 initTestHelpers();
 ```
 
+### If `useDocument` option enabled
+
 In case your tests make use of **experimental `useDocument` option**, take the following additional steps:
 
 ```js
@@ -88,6 +90,14 @@ afterAll(() => {
   teardown();
 });
 ```
+
+### Optional: patch Jest
+
+Until **Jest v27** is published, you might need to patch `jest` in order to load modules with [proper browser/non-browser environments](#73). _Don't do this until you actually encounter issues_.
+
+1. Install [`patch-package`](https://www.npmjs.com/package/patch-package) and follow its setup instructions
+2. Manually update `node_modules/jest-runtime/build/index.js` file and replicate [this commit](https://github.com/facebook/jest/commit/e5a84d92fc906a5bb140f9753b644319cea095da#diff-c0d5b59e96fdc7ffc98405e8afb46d525505bc7b1c24916b5c8482de5a186c00)
+3. Run `npx patch-package jest-runtime` or `yarn patch-package jest-runtime`
 
 ## Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9180,8 +9180,7 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-      "dev": true
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-browserify": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,12 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -4096,6 +4102,132 @@
         "semver-regex": "^2.0.0"
       }
     },
+    "find-yarn-workspace-root": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz",
+      "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^4.0.3",
+        "micromatch": "^3.1.4"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -4211,6 +4343,17 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
       "optional": true
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs-write-stream-atomic": {
       "version": "1.0.10",
@@ -5900,6 +6043,15 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5917,6 +6069,15 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
+    },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
     },
     "kleur": {
       "version": "3.0.3",
@@ -7066,6 +7227,12 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
     "p-each-series": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
@@ -7204,6 +7371,43 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "patch-package": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-6.2.2.tgz",
+      "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
+      "dev": true,
+      "requires": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^2.4.2",
+        "cross-spawn": "^6.0.5",
+        "find-yarn-workspace-root": "^1.2.1",
+        "fs-extra": "^7.0.1",
+        "is-ci": "^2.0.0",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.0",
+        "rimraf": "^2.6.3",
+        "semver": "^5.6.0",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        }
+      }
     },
     "path-browserify": {
       "version": "1.0.1",
@@ -9503,6 +9707,15 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -9760,6 +9973,12 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "fast-glob": "^3.2.4",
     "find-root": "^1.1.0",
     "node-mocks-http": "^1.9.0",
-    "normalize-path": "^3.0.0"
+    "normalize-path": "^3.0.0",
+    "stealthy-require": "^1.1.1"
   },
   "peerDependencies": {
     "next": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "preversion": "npm run prepare",
     "version": "git add package.json",
     "postversion": "git push && git push --tags",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "postinstall": "patch-package"
   },
   "keywords": [
     "next",
@@ -56,6 +57,7 @@
     "jest": "^26.6.3",
     "lint-staged": "^10.5.3",
     "next": "^10.0.3",
+    "patch-package": "^6.2.2",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/patches/jest-runtime+26.6.3.patch
+++ b/patches/jest-runtime+26.6.3.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/jest-runtime/build/index.js b/node_modules/jest-runtime/build/index.js
+index 1c13b1d..46dabeb 100644
+--- a/node_modules/jest-runtime/build/index.js
++++ b/node_modules/jest-runtime/build/index.js
+@@ -715,13 +715,10 @@ class Runtime {
+     ) {
+       moduleRegistry = this._internalModuleRegistry;
+     } else {
+-      if (
+-        this._moduleRegistry.get(modulePath) ||
+-        !this._isolatedModuleRegistry
+-      ) {
+-        moduleRegistry = this._moduleRegistry;
+-      } else {
++      if (this._isolatedModuleRegistry) {
+         moduleRegistry = this._isolatedModuleRegistry;
++      } else {
++        moduleRegistry = this._moduleRegistry;
+       }
+     }
+ 

--- a/src/RouterProvider.tsx
+++ b/src/RouterProvider.tsx
@@ -37,7 +37,6 @@ export default function RouterProvider({
     });
 
     // Avoid errors if page gets unmounted
-    /* istanbul ignore next */
     if (isMounted()) {
       setState({ router: nextRouter, children: pageElement });
     } else {

--- a/src/__tests__/global-object/__fixtures__/pages/gip.js
+++ b/src/__tests__/global-object/__fixtures__/pages/gip.js
@@ -1,17 +1,28 @@
 import React from 'react';
 import { PropsPrinter } from '../../../__utils__';
+
 const window_moduleLoadTime = typeof window !== 'undefined';
 const document_moduleLoadTime = typeof document !== 'undefined';
+const isWeb_moduleLoadTime = window_moduleLoadTime && document_moduleLoadTime;
 
 export default function gip(props) {
+  const window_componentScope = typeof window !== 'undefined';
+  const document_componentScope = typeof document !== 'undefined';
+  const isWeb_componentScope = window_componentScope && document_componentScope;
+
   return (
     <>
       <h2>Page</h2>
       <PropsPrinter
         props={{
           ...props,
-          window_componentScope: typeof window !== 'undefined',
-          document_componentScope: typeof document !== 'undefined',
+          /* Should be hydrated "client" side where browser is defined */
+          window_componentScope,
+          document_componentScope,
+          isWeb_componentScope,
+          window_componentScope_moduleLoadTime: window_moduleLoadTime,
+          document_componentScope_moduleLoadTime: document_moduleLoadTime,
+          isWeb_componentScope_moduleLoadTime: isWeb_moduleLoadTime,
         }}
       />
     </>
@@ -19,10 +30,17 @@ export default function gip(props) {
 }
 
 gip.getInitialProps = async () => {
+  const window_dataFetchingScope = typeof window !== 'undefined';
+  const document_dataFetchingScope = typeof document !== 'undefined';
+  const isWeb_dataFetchingScope =
+    window_dataFetchingScope && document_dataFetchingScope;
+
   return {
     window_moduleLoadTime,
     document_moduleLoadTime,
-    window_dataFetchingScope: typeof window !== 'undefined',
-    document_dataFetchingScope: typeof document !== 'undefined',
+    isWeb_moduleLoadTime,
+    window_dataFetchingScope,
+    document_dataFetchingScope,
+    isWeb_dataFetchingScope,
   };
 };

--- a/src/__tests__/global-object/__fixtures__/pages/gip.js
+++ b/src/__tests__/global-object/__fixtures__/pages/gip.js
@@ -1,28 +1,23 @@
 import React from 'react';
 import { PropsPrinter } from '../../../__utils__';
 
-const window_moduleLoadTime = typeof window !== 'undefined';
-const document_moduleLoadTime = typeof document !== 'undefined';
-const isWeb_moduleLoadTime = window_moduleLoadTime && document_moduleLoadTime;
+const importTime_window = typeof window !== 'undefined';
+const importTime_document = typeof document !== 'undefined';
 
 export default function gip(props) {
-  const window_componentScope = typeof window !== 'undefined';
-  const document_componentScope = typeof document !== 'undefined';
-  const isWeb_componentScope = window_componentScope && document_componentScope;
+  const component_runTime_window = typeof window !== 'undefined';
+  const component_runTime_document = typeof document !== 'undefined';
 
   return (
     <>
       <h2>Page</h2>
       <PropsPrinter
         props={{
+          component_importTime_window: importTime_window,
+          component_importTime_document: importTime_document,
+          component_runTime_window,
+          component_runTime_document,
           ...props,
-          /* Should be hydrated "client" side where browser is defined */
-          window_componentScope,
-          document_componentScope,
-          isWeb_componentScope,
-          window_componentScope_moduleLoadTime: window_moduleLoadTime,
-          document_componentScope_moduleLoadTime: document_moduleLoadTime,
-          isWeb_componentScope_moduleLoadTime: isWeb_moduleLoadTime,
         }}
       />
     </>
@@ -30,17 +25,13 @@ export default function gip(props) {
 }
 
 gip.getInitialProps = async () => {
-  const window_dataFetchingScope = typeof window !== 'undefined';
-  const document_dataFetchingScope = typeof document !== 'undefined';
-  const isWeb_dataFetchingScope =
-    window_dataFetchingScope && document_dataFetchingScope;
+  const dataFetching_runTime_window = typeof window !== 'undefined';
+  const dataFetching_runTime_document = typeof document !== 'undefined';
 
   return {
-    window_moduleLoadTime,
-    document_moduleLoadTime,
-    isWeb_moduleLoadTime,
-    window_dataFetchingScope,
-    document_dataFetchingScope,
-    isWeb_dataFetchingScope,
+    dataFetching_importTime_window: importTime_window,
+    dataFetching_importTime_document: importTime_document,
+    dataFetching_runTime_window,
+    dataFetching_runTime_document,
   };
 };

--- a/src/__tests__/global-object/__fixtures__/pages/ssr.js
+++ b/src/__tests__/global-object/__fixtures__/pages/ssr.js
@@ -1,28 +1,23 @@
 import React from 'react';
 import { PropsPrinter } from '../../../__utils__';
 
-const window_moduleLoadTime = typeof window !== 'undefined';
-const document_moduleLoadTime = typeof document !== 'undefined';
-const isWeb_moduleLoadTime = window_moduleLoadTime && document_moduleLoadTime;
+const importTime_window = typeof window !== 'undefined';
+const importTime_document = typeof document !== 'undefined';
 
 export default function ssr(props) {
-  const window_componentScope = typeof window !== 'undefined';
-  const document_componentScope = typeof document !== 'undefined';
-  const isWeb_componentScope = window_componentScope && document_componentScope;
+  const component_runTime_window = typeof window !== 'undefined';
+  const component_runTime_document = typeof document !== 'undefined';
 
   return (
     <>
       <h2>Page</h2>
       <PropsPrinter
         props={{
+          component_importTime_window: importTime_window,
+          component_importTime_document: importTime_document,
+          component_runTime_window,
+          component_runTime_document,
           ...props,
-          /* Should be hydrated "client" side where browser is defined */
-          window_componentScope,
-          document_componentScope,
-          isWeb_componentScope,
-          window_componentScope_moduleLoadTime: window_moduleLoadTime,
-          document_componentScope_moduleLoadTime: document_moduleLoadTime,
-          isWeb_componentScope_moduleLoadTime: isWeb_moduleLoadTime,
         }}
       />
     </>
@@ -30,19 +25,15 @@ export default function ssr(props) {
 }
 
 export async function getServerSideProps() {
-  const window_dataFetchingScope = typeof window !== 'undefined';
-  const document_dataFetchingScope = typeof document !== 'undefined';
-  const isWeb_dataFetchingScope =
-    window_dataFetchingScope && document_dataFetchingScope;
+  const dataFetching_runTime_window = typeof window !== 'undefined';
+  const dataFetching_runTime_document = typeof document !== 'undefined';
 
   return {
     props: {
-      isWeb_moduleLoadTime,
-      window_moduleLoadTime,
-      document_moduleLoadTime,
-      window_dataFetchingScope,
-      document_dataFetchingScope,
-      isWeb_dataFetchingScope,
+      dataFetching_importTime_window: importTime_window,
+      dataFetching_importTime_document: importTime_document,
+      dataFetching_runTime_window,
+      dataFetching_runTime_document,
     },
   };
 }

--- a/src/__tests__/global-object/__fixtures__/pages/ssr.js
+++ b/src/__tests__/global-object/__fixtures__/pages/ssr.js
@@ -1,17 +1,28 @@
 import React from 'react';
 import { PropsPrinter } from '../../../__utils__';
+
 const window_moduleLoadTime = typeof window !== 'undefined';
 const document_moduleLoadTime = typeof document !== 'undefined';
+const isWeb_moduleLoadTime = window_moduleLoadTime && document_moduleLoadTime;
 
 export default function ssr(props) {
+  const window_componentScope = typeof window !== 'undefined';
+  const document_componentScope = typeof document !== 'undefined';
+  const isWeb_componentScope = window_componentScope && document_componentScope;
+
   return (
     <>
       <h2>Page</h2>
       <PropsPrinter
         props={{
           ...props,
-          window_componentScope: typeof window !== 'undefined',
-          document_componentScope: typeof document !== 'undefined',
+          /* Should be hydrated "client" side where browser is defined */
+          window_componentScope,
+          document_componentScope,
+          isWeb_componentScope,
+          window_componentScope_moduleLoadTime: window_moduleLoadTime,
+          document_componentScope_moduleLoadTime: document_moduleLoadTime,
+          isWeb_componentScope_moduleLoadTime: isWeb_moduleLoadTime,
         }}
       />
     </>
@@ -19,12 +30,19 @@ export default function ssr(props) {
 }
 
 export async function getServerSideProps() {
+  const window_dataFetchingScope = typeof window !== 'undefined';
+  const document_dataFetchingScope = typeof document !== 'undefined';
+  const isWeb_dataFetchingScope =
+    window_dataFetchingScope && document_dataFetchingScope;
+
   return {
     props: {
+      isWeb_moduleLoadTime,
       window_moduleLoadTime,
       document_moduleLoadTime,
-      window_dataFetchingScope: typeof window !== 'undefined',
-      document_dataFetchingScope: typeof document !== 'undefined',
+      window_dataFetchingScope,
+      document_dataFetchingScope,
+      isWeb_dataFetchingScope,
     },
   };
 }

--- a/src/__tests__/global-object/global-object.test.tsx
+++ b/src/__tests__/global-object/global-object.test.tsx
@@ -7,18 +7,29 @@ import GIPPage from './__fixtures__/pages/gip';
 import path from 'path';
 
 const expectedGlobals = {
-  window_moduleLoadTime: true,
-  document_moduleLoadTime: true,
+  window_moduleLoadTime: false,
+  document_moduleLoadTime: false,
+  isWeb_moduleLoadTime: false,
+
   window_dataFetchingScope: false,
   document_dataFetchingScope: false,
+  isWeb_dataFetchingScope: false,
+
   window_componentScope: true,
   document_componentScope: true,
+  isWeb_componentScope: true,
+
+  window_componentScope_moduleLoadTime: true,
+  document_componentScope_moduleLoadTime: true,
+  isWeb_componentScope_moduleLoadTime: true,
 };
 
 const expectedGlobals_GIPClientSide = {
   ...expectedGlobals,
+
   window_dataFetchingScope: true,
   document_dataFetchingScope: true,
+  isWeb_dataFetchingScope: true,
 };
 
 describe('Global object', () => {
@@ -32,6 +43,7 @@ describe('Global object', () => {
         });
         const { container: actual } = render(page);
 
+        // Client side navigation to SSR page
         if (renderType === 'client') {
           userEvent.click(screen.getByText('Go to SSR'));
           await screen.findByText('Page');

--- a/src/__tests__/global-object/global-object.test.tsx
+++ b/src/__tests__/global-object/global-object.test.tsx
@@ -7,29 +7,23 @@ import GIPPage from './__fixtures__/pages/gip';
 import path from 'path';
 
 const expectedGlobals = {
-  window_moduleLoadTime: false,
-  document_moduleLoadTime: false,
-  isWeb_moduleLoadTime: false,
+  component_importTime_window: true,
+  component_importTime_document: true,
+  component_runTime_window: true,
+  component_runTime_document: true,
 
-  window_dataFetchingScope: false,
-  document_dataFetchingScope: false,
-  isWeb_dataFetchingScope: false,
-
-  window_componentScope: true,
-  document_componentScope: true,
-  isWeb_componentScope: true,
-
-  window_componentScope_moduleLoadTime: true,
-  document_componentScope_moduleLoadTime: true,
-  isWeb_componentScope_moduleLoadTime: true,
+  dataFetching_importTime_window: false,
+  dataFetching_importTime_document: false,
+  dataFetching_runTime_window: false,
+  dataFetching_runTime_document: false,
 };
 
 const expectedGlobals_GIPClientSide = {
   ...expectedGlobals,
-
-  window_dataFetchingScope: true,
-  document_dataFetchingScope: true,
-  isWeb_dataFetchingScope: true,
+  dataFetching_importTime_window: true,
+  dataFetching_importTime_document: true,
+  dataFetching_runTime_window: true,
+  dataFetching_runTime_document: true,
 };
 
 describe('Global object', () => {

--- a/src/_app/fetchAppData.ts
+++ b/src/_app/fetchAppData.ts
@@ -18,7 +18,7 @@ export default async function fetchAppData({
     return;
   }
 
-  const customApp = customAppFile.default;
+  const customApp = customAppFile.server.default;
   if (customApp.getInitialProps) {
     const { asPath, pathname, query, route, basePath } = makeRouterMock({
       options,
@@ -28,7 +28,7 @@ export default async function fetchAppData({
     const ctx: AppContext = {
       // @NOTE AppTree is currently just a stub
       AppTree: Fragment,
-      Component: pageObject.page.default,
+      Component: pageObject.page.client.default,
       ctx: makeGetInitialPropsContext({
         pageObject,
         options,

--- a/src/_app/fetchAppData.ts
+++ b/src/_app/fetchAppData.ts
@@ -12,7 +12,7 @@ export default async function fetchAppData({
   pageObject: PageObject;
   options: ExtendedOptions;
 }): Promise<AppInitialProps | undefined> {
-  const customAppFile = await getCustomAppFile({ options });
+  const customAppFile = getCustomAppFile({ options });
 
   if (!customAppFile) {
     return;

--- a/src/_app/getCustomAppFile.ts
+++ b/src/_app/getCustomAppFile.ts
@@ -8,7 +8,7 @@ export default function getCustomAppFile({
   options: ExtendedOptions;
 }) {
   return loadPageIfExists<NextCustomAppFile>({
-    options,
     pagePath: APP_PATH,
+    options,
   });
 }

--- a/src/_app/render.tsx
+++ b/src/_app/render.tsx
@@ -16,15 +16,15 @@ export default function renderApp({
   const customAppFile = getCustomAppFile({ options });
   let AppComponent;
 
-  if (useApp && customAppFile?.default) {
-    AppComponent = customAppFile.default;
+  if (useApp && customAppFile?.client?.default) {
+    AppComponent = customAppFile.client.default;
   } else {
     AppComponent = DefaultApp;
   }
 
   return (
     <AppComponent
-      Component={pageObject.page.default}
+      Component={pageObject.page.client.default}
       pageProps={pageData.props}
     />
   );

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -23,7 +23,7 @@ export default async function renderDocument({
   const customDocumentFile = getCustomDocumentFile({ options });
 
   const Document = customDocumentFile
-    ? customDocumentFile.default
+    ? customDocumentFile.client.default
     : DefaultDocument;
 
   let head: JSX.Element[] = [];

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -40,10 +40,15 @@ export type ExtendedOptions = OptionsWithDefaults & {
 /*
  * Page
  */
+export type PageFile<FileType> = {
+  client: FileType;
+  server: FileType;
+};
+
 export type PageParams = ParsedUrlQuery;
 
 export type PageObject = {
-  page: NextPageFile;
+  page: PageFile<NextPageFile>;
   route: string;
   pagePath: string;
   params: PageParams;

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -106,16 +106,17 @@ export default async function fetchPageData({
   options: ExtendedOptions;
 }): Promise<PageData> {
   const { page, params } = pageObject;
-  ensureNoMultipleDataFetchingMethods({ page });
+  ensureNoMultipleDataFetchingMethods({ page: page.server });
 
   // getInitialProps is not called when custom App has the same method
-  if (page.default.getInitialProps && !appInitialProps) {
+  // @TODO: use options.isClientSideNavigation to use server/client page version
+  if (page.client.default.getInitialProps && !appInitialProps) {
     const ctx: NextPageContext = makeGetInitialPropsContext({
       options,
       pageObject,
     });
 
-    const { getInitialProps } = page.default;
+    const { getInitialProps } = page.client.default;
     const initialProps = options.isClientSideNavigation
       ? await getInitialProps(ctx)
       : await executeAsIfOnServer(() => getInitialProps(ctx));
@@ -123,8 +124,8 @@ export default async function fetchPageData({
     return { props: initialProps };
   }
 
-  if (page.getServerSideProps) {
-    const { getServerSideProps } = page;
+  if (page.server.getServerSideProps) {
+    const { getServerSideProps } = page.server;
     const ctx: GetServerSidePropsContext<
       typeof params
     > = makeGetServerSidePropsContext({ options, pageObject });
@@ -133,13 +134,13 @@ export default async function fetchPageData({
     return mergePageDataWithAppData({ pageData, appInitialProps });
   }
 
-  if (page.getStaticProps) {
+  if (page.server.getStaticProps) {
     const ctx: GetStaticPropsContext<typeof params> = makeStaticPropsContext({
       pageObject,
     });
     // @TODO introduce `getStaticPaths` logic
     // https://nextjs.org/docs/basic-features/data-fetching#getstaticpaths-static-generation
-    const pageData = await page.getStaticProps(ctx);
+    const pageData = await page.server.getStaticProps(ctx);
     ensurePageDataHasProps({ pageData });
     return mergePageDataWithAppData({ pageData, appInitialProps });
   }

--- a/src/getPageObject.ts
+++ b/src/getPageObject.ts
@@ -21,7 +21,7 @@ export default async function getPageObject({
       options,
     });
 
-    if (!page.default) {
+    if (!page.client.default) {
       throw new Error(
         '[next-page-tester]: No default export found for given route'
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,11 @@
+import { executeWithFreshModules } from './utils';
+
+export const requireAsIfOnServer = <FileType>(path: string): FileType => {
+  return executeWithFreshModules(() => {
+    return executeAsIfOnServerSync<FileType>(() => require(path));
+  });
+};
+
 export const executeAsIfOnServer = async <T>(f: () => T) => {
   const tmpWindow = global.window;
   const tmpDocument = global.document;
@@ -15,7 +23,7 @@ export const executeAsIfOnServer = async <T>(f: () => T) => {
   return result;
 };
 
-export const executeAsIfOnServerSync = <T>(f: () => T) => {
+export const executeAsIfOnServerSync = <T>(f: () => T): T => {
   const tmpWindow = global.window;
   const tmpDocument = global.document;
 

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -16,8 +16,9 @@ export function initTestHelpers() {
   if (isJSDOMEnvironment()) {
     /*
      * This is a dreadful hack to resolve this Next.js module in "non-browser" environment mode.
-     * It allows pages to add new `<head>` elements on first render
-     * https://github.com/vercel/next.js/blob/v10.0.3/packages/next/next-server/lib/side-effect.tsx#L3
+     * It allows pages to add new `<head>` elements on first render since we currently
+     * never render component in server environment but we directly render in client mode
+     * https://github.com/vercel/next.js/blob/v10.0.3/packages/next/next-server/lib/side-effect.tsx#L36
      */
     executeAsIfOnServerSync(() => {
       require('next/head');

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -16,11 +16,11 @@ export function initTestHelpers() {
   if (isJSDOMEnvironment()) {
     /*
      * This is a dreadful hack to resolve this Next.js module in "non-browser" environment mode.
-     * It affects `<head>` elements
+     * It allows pages to add new `<head>` elements on first render
      * https://github.com/vercel/next.js/blob/v10.0.3/packages/next/next-server/lib/side-effect.tsx#L3
      */
     executeAsIfOnServerSync(() => {
-      require('next/dist/next-server/lib/side-effect');
+      require('next/head');
     });
 
     // Mock IntersectionObserver (Link component relies on it)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,6 +109,7 @@ export function useMountedState(): () => boolean {
 }
 
 export function executeWithFreshModules<T>(f: () => T): T {
+  /* istanbul ignore else */
   if (typeof jest !== 'undefined') {
     let result: T;
     jest.isolateModules(() => {
@@ -116,7 +117,9 @@ export function executeWithFreshModules<T>(f: () => T): T {
     });
     // @ts-ignore
     return result;
-  } else {
+  }
+  // @NOTE this branch will never be execute by Jest
+  else {
     return stealthyRequire(require.cache, f);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { existsSync } from 'fs';
 import loadConfig from 'next/dist/next-server/server/config';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 import path from 'path';
+import stealthyRequire from 'stealthy-require';
 
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
@@ -108,10 +109,14 @@ export function useMountedState(): () => boolean {
 }
 
 export function executeWithFreshModules<T>(f: () => T): T {
-  let result: T;
-  jest.isolateModules(() => {
-    result = f();
-  });
-  // @ts-ignore
-  return result;
+  if (typeof jest !== 'undefined') {
+    let result: T;
+    jest.isolateModules(() => {
+      result = f();
+    });
+    // @ts-ignore
+    return result;
+  } else {
+    return stealthyRequire(require.cache, f);
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,3 +106,12 @@ export function useMountedState(): () => boolean {
 
   return get;
 }
+
+export function executeWithFreshModules<T>(f: () => T): T {
+  let result: T;
+  jest.isolateModules(() => {
+    result = f();
+  });
+  // @ts-ignore
+  return result;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "outDir": "dist",
     "allowJs": true,
     "jsx": "react",
-    "declaration": true
+    "declaration": true,
+    "paths": {
+      "*": ["./@types/*"]
+    }
   },
   "include": ["./src/index.ts"]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR tries to extend current `server` idea to workaround #67 and #64. The main issue here consists of being able to access the same module in both "browser" and "non-browser" environment. This approach tries to consider "browser" mode modules as default and keep a "non-browser" copy of the relevant modules in a `server` instance initialized when `getPage` gets called.

Relevant modules are:
- pages
- custom app/document
- some Next.js modules (like `next/dist/next-server/lib/side-effect`)

## What is the current behaviour?

You can also link to an open issue here.

## What is the new behaviour?

...

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
