### PR TITLE
fix: patch Jest on prepare (dev-only)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "test:source": "npm run test:format && npm run test:ts && npm t -- --coverage",
     "test:ts": "tsc --noEmit",
     "test:format": "prettier --check .",
-    "prepare": "npm run test:source && npm run compile",
+    "prepare": "patch-package && npm run test:source && npm run compile",
     "preversion": "npm run prepare",
     "version": "git add package.json",
     "postversion": "git push && git push --tags",
-    "format": "prettier --write .",
-    "postinstall": "patch-package"
+    "format": "prettier --write ."
   },
   "keywords": [
     "next",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

`patch-package` command is fired when packages is installed by final user. (Should be a dev-only command, instead)

## What is the new behaviour?

Trigger `patch-package` on `prepare` (which fires only at dev install)

## Does this PR introduce a breaking change?

No.

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
