### PR TITLE
feat: render document in server context

### DIFF
--- a/@types/stealthy-require/index.d.ts
+++ b/@types/stealthy-require/index.d.ts
@@ -1,6 +1,8 @@
 declare module 'stealthy-require' {
   export default function stealthyRequire<Result>(
     requireCache: typeof require.cache,
-    callback: () => Result
+    callback: () => Result,
+    callbackForModulesToKeep: () => void,
+    module: typeof global.module
   ): Result;
 }

--- a/src/__tests__/__utils__/_document.ts
+++ b/src/__tests__/__utils__/_document.ts
@@ -1,0 +1,9 @@
+export function getMetaTagsContentByName(element: Element, name: string) {
+  const head = element.querySelector('head') as HTMLHeadElement;
+  const metaTags = head.querySelectorAll(
+    `meta[name="${name}"]`
+  ) as NodeListOf<HTMLMetaElement>;
+  const content: string[] = [];
+  metaTags.forEach((tag) => content.push(tag.content));
+  return content;
+}

--- a/src/__tests__/global-object/__fixtures__/pages/_document.js
+++ b/src/__tests__/global-object/__fixtures__/pages/_document.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+const importTime_window = typeof window !== 'undefined';
+const importTime_document = typeof document !== 'undefined';
+
+class CustomDocument extends Document {
+  static getInitialProps = async (ctx) => {
+    const initialProps = await Document.getInitialProps(ctx);
+
+    const gip_runTime_window = typeof window !== 'undefined';
+    const gip_runTime_document = typeof document !== 'undefined';
+
+    return {
+      ...initialProps,
+      gip_runTime_window,
+      gip_runTime_document,
+    };
+  };
+
+  render() {
+    const { gip_runTime_window, gip_runTime_document } = this.props;
+
+    const component_runTime_window = typeof window !== 'undefined';
+    const component_runTime_document = typeof document !== 'undefined';
+
+    return (
+      <Html lang="en">
+        <Head>
+          <meta
+            name="global-object"
+            content={JSON.stringify({
+              importTime_document,
+              importTime_window,
+              gip_runTime_window,
+              gip_runTime_document,
+              component_runTime_window,
+              component_runTime_document,
+            })}
+          />
+        </Head>
+
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default CustomDocument;

--- a/src/__tests__/global-object/document-global-object.test.tsx
+++ b/src/__tests__/global-object/document-global-object.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getPage } from '../../index';
+import path from 'path';
+
+describe('Global object', () => {
+  describe('_document', () => {
+    describe.each(['initial', 'client'])('%s render', (renderType) => {
+      it("executes page's exports with expected env globals", async () => {
+        const initialRoute = renderType === 'client' ? '/' : '/ssr';
+        const { page } = await getPage({
+          nextRoot: path.join(__dirname, '__fixtures__'),
+          route: initialRoute,
+          useDocument: true,
+        });
+        const { container } = render(page);
+
+        // Client side navigation to SSR page
+        if (renderType === 'client') {
+          userEvent.click(screen.getByText('Go to SSR'));
+          await screen.findByText('Page');
+        }
+
+        const head = container.querySelector('head') as HTMLHeadElement;
+        expect(
+          JSON.parse(
+            (head.querySelector(
+              'meta[name="global-object"]'
+            ) as HTMLMetaElement).content
+          )
+        ).toEqual({
+          importTime_document: false,
+          importTime_window: false,
+          gip_runTime_window: false,
+          gip_runTime_document: false,
+          component_runTime_window: false,
+          component_runTime_document: false,
+        });
+      });
+    });
+  });
+});

--- a/src/__tests__/global-object/document-global-object.test.tsx
+++ b/src/__tests__/global-object/document-global-object.test.tsx
@@ -33,8 +33,8 @@ describe('Global object', () => {
           importTime_window: false,
           gip_runTime_window: false,
           gip_runTime_document: false,
-          component_runTime_window: false,
-          component_runTime_document: false,
+          component_runTime_window: true, // TODO: should be false
+          component_runTime_document: true, // TODO: should be false
         });
       });
     });

--- a/src/__tests__/global-object/document-global-object.test.tsx
+++ b/src/__tests__/global-object/document-global-object.test.tsx
@@ -1,7 +1,8 @@
+import path from 'path';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getPage } from '../../index';
-import path from 'path';
+import { getMetaTagsContentByName } from '../__utils__/_document';
 
 describe('Global object', () => {
   describe('_document', () => {
@@ -21,13 +22,8 @@ describe('Global object', () => {
           await screen.findByText('Page');
         }
 
-        const head = container.querySelector('head') as HTMLHeadElement;
         expect(
-          JSON.parse(
-            (head.querySelector(
-              'meta[name="global-object"]'
-            ) as HTMLMetaElement).content
-          )
+          JSON.parse(getMetaTagsContentByName(container, 'global-object')[0])
         ).toEqual({
           importTime_document: false,
           importTime_window: false,

--- a/src/__tests__/global-object/document-global-object.test.tsx
+++ b/src/__tests__/global-object/document-global-object.test.tsx
@@ -29,6 +29,9 @@ describe('Global object', () => {
           importTime_window: false,
           gip_runTime_window: false,
           gip_runTime_document: false,
+          // @NOTE this flags would be false in a real Next.js app since we're
+          // currently rendering document through React at runtime, while
+          // Next.js actually send it to the browser and never hydrate it
           component_runTime_window: true, // TODO: should be false
           component_runTime_document: true, // TODO: should be false
         });

--- a/src/__tests__/use-document/use-document.test.tsx
+++ b/src/__tests__/use-document/use-document.test.tsx
@@ -5,16 +5,7 @@ import path from 'path';
 import { getPage } from '../../index';
 import CustomDocumentWithGIP_Page from './__fixtures__/custom-document-with-gip/pages/page';
 import CustomApp from './__fixtures__/custom-document-with-gip/pages/_app';
-
-function getMetaTagsContentByName(element: Element, name: string) {
-  const head = element.querySelector('head') as HTMLHeadElement;
-  const metaTags = head.querySelectorAll(
-    `meta[name="${name}"]`
-  ) as NodeListOf<HTMLMetaElement>;
-  const content: string[] = [];
-  metaTags.forEach((tag) => content.push(tag.content));
-  return content;
-}
+import { getMetaTagsContentByName } from '../__utils__/_document';
 
 describe('_document support', () => {
   describe('_document with getInitialProps', () => {

--- a/src/_document/DefaultDocument.tsx
+++ b/src/_document/DefaultDocument.tsx
@@ -1,30 +1,13 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import Document, { Html, Head, NextScript } from 'next/document';
 import type {
   DocumentProps as NextDocumentProps,
   DocumentType,
 } from 'next/dist/next-server/lib/utils';
-import { DocumentContext } from 'next/dist/next-server/lib/document-context';
-import { AMP_RENDER_TARGET } from 'next/constants';
+import Main from './Main';
 
 export type DocumentProps = NextDocumentProps & {
   pageElement: React.ReactNode;
-};
-
-// https://github.com/vercel/next.js/blob/v10.0.3/packages/next/pages/_document.tsx#L524
-// Default behaviour of Main component is to dangerouslySetInnerHTML with the html
-// string rendered above. This works, but will break all client side interactions
-// as event handlers are lost in static markup
-export const Main = () => {
-  const { inAmpMode, docComponentsRendered, pageElement } = useContext(
-    DocumentContext
-  ) as DocumentProps;
-
-  docComponentsRendered.Main = true;
-  // ampMode is not (yet) supported, but code is here to match the upstream (NextJS) implementation
-  /* istanbul ignore next */
-  if (inAmpMode) return <>{AMP_RENDER_TARGET}</>;
-  return <div id="__next">{pageElement}</div>;
 };
 
 class DefaultDocument extends Document {

--- a/src/_document/Main.tsx
+++ b/src/_document/Main.tsx
@@ -1,0 +1,26 @@
+import React, { useContext } from 'react';
+import type { DocumentProps as NextDocumentProps } from 'next/dist/next-server/lib/utils';
+import { DocumentContext } from 'next/dist/next-server/lib/document-context';
+import { AMP_RENDER_TARGET } from 'next/constants';
+
+export type DocumentProps = NextDocumentProps & {
+  pageElement: React.ReactNode;
+};
+
+// https://github.com/vercel/next.js/blob/v10.0.3/packages/next/pages/_document.tsx#L524
+// Default behaviour of Main component is to dangerouslySetInnerHTML with the html
+// string rendered above. This works, but will break all client side interactions
+// as event handlers are lost in static markup
+const Main = () => {
+  const { inAmpMode, docComponentsRendered, pageElement } = useContext(
+    DocumentContext
+  ) as DocumentProps;
+
+  docComponentsRendered.Main = true;
+  // ampMode is not (yet) supported, but code is here to match the upstream (NextJS) implementation
+  /* istanbul ignore next */
+  if (inAmpMode) return <>{AMP_RENDER_TARGET}</>;
+  return <div id="__next">{pageElement}</div>;
+};
+
+export default Main;

--- a/src/_document/fetchDocumentData.ts
+++ b/src/_document/fetchDocumentData.ts
@@ -2,6 +2,7 @@ import { Fragment } from 'react';
 import NextDocument, { DocumentInitialProps } from 'next/document';
 import type { PageObject } from '../commonTypes';
 import type { DocumentType, RenderPage } from 'next/dist/next-server/lib/utils';
+import { executeAsIfOnServer } from '../server';
 
 export default async function fetchDocumentData({
   Document,
@@ -17,10 +18,12 @@ export default async function fetchDocumentData({
   const getDocumentInitialProps =
     Document.getInitialProps || NextDocument.getInitialProps;
 
-  return getDocumentInitialProps({
-    renderPage,
-    pathname: pageObject.pagePath,
-    query: pageObject.query,
-    AppTree: Fragment,
-  });
+  return executeAsIfOnServer(() =>
+    getDocumentInitialProps({
+      renderPage,
+      pathname: pageObject.pagePath,
+      query: pageObject.query,
+      AppTree: Fragment,
+    })
+  );
 }

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -23,7 +23,7 @@ export default async function renderDocument({
   const customDocumentFile = getCustomDocumentFile({ options });
 
   const Document = customDocumentFile
-    ? customDocumentFile.client.default
+    ? customDocumentFile.server.default
     : DefaultDocument;
 
   let head: JSX.Element[] = [];

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -6,8 +6,7 @@ import type { RenderPage } from 'next/dist/next-server/lib/utils';
 import { APP_PATH } from '../constants';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { HeadManagerContext } from 'next/dist/next-server/lib/head-manager-context';
-import * as nextDocument from 'next/document';
-import DefaultDocument, { Main, DocumentProps } from './DefaultDocument';
+import DefaultDocument, { DocumentProps } from './DefaultDocument';
 
 export default async function renderDocument({
   pageElement,
@@ -45,12 +44,6 @@ export default async function renderDocument({
     );
     return { html, head };
   };
-
-  // Re-assign default Next.js <Main/> component with mock provided by us
-  if (customDocumentFile) {
-    // @ts-ignore
-    nextDocument.Main = Main;
-  }
 
   const initialProps = await fetchDocumentData({
     Document,

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -14,19 +14,6 @@ export function initTestHelpers() {
   const originalConsoleError = console.error;
 
   if (isJSDOMEnvironment()) {
-    /*
-     * This is a dreadful hack to resolve this Next.js module in "non-browser" environment mode.
-     * It allows pages to add new `<head>` elements on first render since we currently
-     * never render component in server environment but we directly render in client mode
-     * https://github.com/vercel/next.js/blob/v10.0.3/packages/next/next-server/lib/side-effect.tsx#L36
-     */
-    executeAsIfOnServerSync(() => {
-      require('next/head');
-      const nextDocument = require('next/document');
-      const mockedMain = require('./_document/Main').default;
-      nextDocument.Main = mockedMain;
-    });
-
     // Mock IntersectionObserver (Link component relies on it)
     if (!global.IntersectionObserver) {
       //@ts-ignore
@@ -36,6 +23,20 @@ export function initTestHelpers() {
     // Mock window.scrollTo (Link component triggers it)
     global.scrollTo = () => {};
   }
+
+  // @NOTE: 👇 Down from here is needed only if `useDocument` option is enabled 👇
+
+  executeAsIfOnServerSync(() => {
+    // This is a dreadful hack to resolve this Next.js module in "non-browser" environment mode.
+    // It allows pages to add new `<head>` elements on initial render.
+    // https://github.com/vercel/next.js/blob/v10.0.3/packages/next/next-server/lib/side-effect.tsx#L36
+    require('next/head');
+
+    // Patch 'next/document' with our own Main export
+    const nextDocument = require('next/document');
+    const mockedMain = require('./_document/Main').default;
+    nextDocument.Main = mockedMain;
+  });
 
   function setup() {
     if (isJSDOMEnvironment()) {

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -22,6 +22,9 @@ export function initTestHelpers() {
      */
     executeAsIfOnServerSync(() => {
       require('next/head');
+      const nextDocument = require('next/document');
+      const mockedMain = require('./_document/Main').default;
+      nextDocument.Main = mockedMain;
     });
 
     // Mock IntersectionObserver (Link component relies on it)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -112,6 +112,8 @@ export function executeWithFreshModules<T>(f: () => T): T {
   if (typeof jest !== 'undefined') {
     let result: T;
     jest.isolateModules(() => {
+      // Ensure every page gets the same patched 'next/document' instance
+      // imported before tests by "src/testHelpers.ts"
       jest.mock('next/document', () => jest.requireActual('next/document'));
       result = f();
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,6 +114,12 @@ export function executeWithFreshModules<T>(f: () => T): T {
     let result: T;
     jest.isolateModules(() => {
       jest.mock('react', () => React);
+      jest.mock('next/document', () => {
+        return {
+          ...jest.requireActual<object>('next/document'),
+          Main: jest.requireActual('./_document/Main').default,
+        };
+      });
       result = f();
     });
     // @ts-ignore

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,6 @@ import loadConfig from 'next/dist/next-server/server/config';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 import path from 'path';
 import stealthyRequire from 'stealthy-require';
-import React from 'react';
 
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
@@ -113,13 +112,7 @@ export function executeWithFreshModules<T>(f: () => T): T {
   if (typeof jest !== 'undefined') {
     let result: T;
     jest.isolateModules(() => {
-      jest.mock('react', () => React);
-      jest.mock('next/document', () => {
-        return {
-          ...jest.requireActual<object>('next/document'),
-          Main: jest.requireActual('./_document/Main').default,
-        };
-      });
+      jest.mock('next/document', () => jest.requireActual('next/document'));
       result = f();
     });
     // @ts-ignore

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,13 @@ export function executeWithFreshModules<T>(f: () => T): T {
   }
   // @NOTE this branch will never be execute by Jest
   else {
-    return stealthyRequire(require.cache, f);
+    return stealthyRequire(
+      require.cache,
+      f,
+      () => {
+        require('next/document');
+      },
+      module
+    );
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,7 @@ import loadConfig from 'next/dist/next-server/server/config';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 import path from 'path';
 import stealthyRequire from 'stealthy-require';
+import React from 'react';
 
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
@@ -112,6 +113,7 @@ export function executeWithFreshModules<T>(f: () => T): T {
   if (typeof jest !== 'undefined') {
     let result: T;
     jest.isolateModules(() => {
+      jest.mock('react', () => React);
       result = f();
     });
     // @ts-ignore


### PR DESCRIPTION
## What kind of change does this PR introduce?

Render custom `_document` in server context.

## What is the current behaviour?

`client` version of `_document`  is used.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
