### PR TITLE
fix: prevent app from executing data fetching when useApp is false

### DIFF
--- a/src/__tests__/use-app/__fixtures__/custom-app-with-gip/pages/page.js
+++ b/src/__tests__/use-app/__fixtures__/custom-app-with-gip/pages/page.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { PropsPrinter } from '../../../../__utils__/';
+
+export default function CustomAppWithGIP_Page({ ...props }) {
+  return (
+    <>
+      custom-app-with-gip/page -
+      <PropsPrinter props={props} />
+    </>
+  );
+}

--- a/src/__tests__/use-app/__fixtures__/special-extension/pages/_app.tsx
+++ b/src/__tests__/use-app/__fixtures__/special-extension/pages/_app.tsx
@@ -10,7 +10,7 @@ export default function CustomApp({
   return (
     <>
       _app.jsx
-      <Component {...pageProps} />;
+      <Component {...pageProps} />
     </>
   );
 }

--- a/src/__tests__/use-app/use-app.test.tsx
+++ b/src/__tests__/use-app/use-app.test.tsx
@@ -7,6 +7,7 @@ import CustomAppWithGIP_AppContextPage from './__fixtures__/custom-app-with-gip/
 import CustomAppWithGIP_SSRPage from './__fixtures__/custom-app-with-gip/pages/ssr';
 import CustomAppWithGIP_SSGPage from './__fixtures__/custom-app-with-gip/pages/ssg';
 import CustomAppWithGIP_GIPPage from './__fixtures__/custom-app-with-gip/pages/gip';
+import CustomAppWithGIP_Page from './__fixtures__/custom-app-with-gip/pages/page';
 
 import CustomAppWithNextAppGIP from './__fixtures__/custom-app-with-next-app-gip/pages/_app';
 import CustomAppWithNextAppGIP_GIP from './__fixtures__/custom-app-with-next-app-gip/pages/gip';
@@ -159,14 +160,14 @@ describe('_app support', () => {
   });
 
   describe('"useApp" === false while _app component available', () => {
-    it('does not render custom App', async () => {
+    it('does not render custom App nor receives props from it', async () => {
       const { page } = await getPage({
-        nextRoot: __dirname + '/__fixtures__/special-extension',
+        nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route: '/page',
         useApp: false,
       });
       const { container: actual } = render(page);
-      const { container: expected } = render(<SpecialExtensionPage />);
+      const { container: expected } = render(<CustomAppWithGIP_Page />);
       expect(actual).toEqual(expected);
     });
   });

--- a/src/_app/fetchAppData.ts
+++ b/src/_app/fetchAppData.ts
@@ -12,9 +12,10 @@ export default async function fetchAppData({
   pageObject: PageObject;
   options: ExtendedOptions;
 }): Promise<AppInitialProps | undefined> {
+  const { useApp } = options;
   const customAppFile = getCustomAppFile({ options });
 
-  if (!customAppFile) {
+  if (!useApp || !customAppFile) {
     return;
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

Pages receive `pageProps` from custom app even when `useApp` is set to `false`

## What is the new behaviour?

Ensure `useApp = false` prevents custom app from fetching data whatsoever

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
