### PR TITLE
[next] feature: expose render and renderHTML methods

### DIFF
--- a/src/__tests__/__utils__/expectDOMElementsToMatch.ts
+++ b/src/__tests__/__utils__/expectDOMElementsToMatch.ts
@@ -1,0 +1,17 @@
+const REACT_NEW_LINE_COMMENTS_REGEX = /<!-- -->/g;
+const REACT_DATA_REACT_ROOT = / data-reactroot=\"\"/g;
+export function stripReactReactExtraMarkup(string: string): string {
+  return string
+    .replace(REACT_NEW_LINE_COMMENTS_REGEX, '')
+    .replace(REACT_DATA_REACT_ROOT, '');
+}
+
+export function expectDOMElementsToMatch(
+  actual: Element,
+  expected: Element
+): void {
+  const actualString = stripReactReactExtraMarkup(actual.outerHTML);
+  const expectedString = stripReactReactExtraMarkup(expected.outerHTML);
+
+  return expect(actualString).toEqual(expectedString);
+}

--- a/src/__tests__/__utils__/index.ts
+++ b/src/__tests__/__utils__/index.ts
@@ -4,3 +4,4 @@ export { RouterQueryPrinter } from './RouterQueryPrinter';
 export { sleep } from './sleep';
 export { stringify } from './stringify';
 export { wrapWithNextRoot } from './wrapWithNextRoot';
+export { expectDOMElementsToMatch } from './expectDOMElementsToMatch';

--- a/src/__tests__/new-returns/__fixtures__/pages/page.tsx
+++ b/src/__tests__/new-returns/__fixtures__/pages/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default function Page() {
-  return <div className="PAGE">hydration/page</div>;
+  return <div className="PAGE">new-returns/page</div>;
 }

--- a/src/__tests__/new-returns/new-returns.test.tsx
+++ b/src/__tests__/new-returns/new-returns.test.tsx
@@ -28,7 +28,9 @@ describe('New returns', () => {
         nextRoot: path.join(__dirname, '__fixtures__'),
         route: '/page',
       });
-      renderHTML();
+      const { nextRoot } = renderHTML();
+      const actualNextRoot = document.getElementById('__next');
+      expect(nextRoot).toBe(actualNextRoot);
 
       const actualHtml = document.documentElement;
       const { container: expectedHtml } = TLRender(
@@ -55,7 +57,9 @@ describe('New returns', () => {
         nextRoot: path.join(__dirname, '__fixtures__'),
         route: '/page',
       });
-      render();
+      const { nextRoot } = render();
+      const actualNextRoot = document.getElementById('__next');
+      expect(nextRoot).toBe(actualNextRoot);
 
       const actualHtml = document.documentElement;
       const { container: expectedHtml } = TLRender(

--- a/src/__tests__/new-returns/new-returns.test.tsx
+++ b/src/__tests__/new-returns/new-returns.test.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
+import { render as TLRender } from '@testing-library/react';
 import { getPage } from '../../index';
 import path from 'path';
 import App from './__fixtures__/pages/_app';
 import Page from './__fixtures__/pages/page';
 import { wrapWithNextRoot } from '../__utils__';
+import { expectDOMElementsToMatch } from '../__utils__';
 
 describe('New returns', () => {
   describe('html', () => {
@@ -17,6 +19,60 @@ describe('New returns', () => {
       const expectedPage = wrapWithNextRoot(<App Component={Page} />);
       const expectedHtml = ReactDOMServer.renderToString(expectedPage);
       expect(html).toEqual(expectedHtml);
+    });
+  });
+
+  describe('renderHTML', () => {
+    it('append to DOM expected elements', async () => {
+      const { renderHTML } = await getPage({
+        nextRoot: path.join(__dirname, '__fixtures__'),
+        route: '/page',
+      });
+      renderHTML();
+
+      const actualHtml = document.documentElement;
+      const { container: expectedHtml } = TLRender(
+        <>
+          <head />
+          <body>
+            <div id="__next">
+              <App Component={Page} />
+            </div>
+          </body>
+        </>,
+        {
+          container: document.createElement('html'),
+        }
+      );
+
+      expectDOMElementsToMatch(actualHtml, expectedHtml);
+    });
+  });
+
+  describe('render', () => {
+    it('hydrate in DOM expected element', async () => {
+      const { render } = await getPage({
+        nextRoot: path.join(__dirname, '__fixtures__'),
+        route: '/page',
+      });
+      render();
+
+      const actualHtml = document.documentElement;
+      const { container: expectedHtml } = TLRender(
+        <>
+          <head />
+          <body>
+            <div id="__next">
+              <App Component={Page} />
+            </div>
+          </body>
+        </>,
+        {
+          container: document.createElement('html'),
+        }
+      );
+
+      expectDOMElementsToMatch(actualHtml, expectedHtml);
     });
   });
 });

--- a/src/__tests__/new-returns/new-returns.test.tsx
+++ b/src/__tests__/new-returns/new-returns.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import { render as TLRender } from '@testing-library/react';
+import { render as TLRender, screen } from '@testing-library/react';
 import { getPage } from '../../index';
 import path from 'path';
 import App from './__fixtures__/pages/_app';
@@ -48,6 +48,17 @@ describe('New returns', () => {
       );
 
       expectDOMElementsToMatch(actualHtml, expectedHtml);
+    });
+
+    describe('global @testing-library screen', () => {
+      it('hooks into current body element', async () => {
+        const { renderHTML } = await getPage({
+          nextRoot: path.join(__dirname, '__fixtures__'),
+          route: '/page',
+        });
+        renderHTML();
+        screen.getByText('new-returns/page');
+      });
     });
   });
 

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { existsSync } from 'fs';
 import makePageElement from './makePageElement';
+import makeRenderMethods from './makeRenderMethods';
 import RouterProvider from './RouterProvider';
 import { renderDocument } from './_document';
 import { renderApp } from './_app';
@@ -40,7 +41,12 @@ export default async function getPage({
   router = (router) => router,
   useApp = true,
   useDocument = false,
-}: Options): Promise<{ page: React.ReactElement; html: string }> {
+}: Options): Promise<
+  {
+    page: React.ReactElement;
+    html: string;
+  } & ReturnType<typeof makeRenderMethods>
+> {
   const optionsWithDefaults: OptionsWithDefaults = {
     route,
     nextRoot,
@@ -143,5 +149,6 @@ export default async function getPage({
     // @NOTE Temporary hack to keep tests green
     page: useDocument ? serverPageElement : clientPageElement,
     html,
+    ...makeRenderMethods({ pageElement: clientPageElement, html }),
   };
 }

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -1,0 +1,34 @@
+import { render as TLRender } from '@testing-library/react';
+
+// @TODO: Make this methods overridable via options
+export default function makeRenderMethods({
+  html,
+  pageElement,
+}: {
+  html: string;
+  pageElement: JSX.Element;
+}) {
+  // Replace the whole document content with SSR html
+  function renderHTML() {
+    document.documentElement.innerHTML = html;
+  }
+
+  function render() {
+    renderHTML();
+    const nextRootElement = document.getElementById('__next');
+    if (!nextRootElement) {
+      throw new Error('[next-page-tester] Missing __next div');
+    }
+
+    // Hydrate page element in existing DOM
+    TLRender(pageElement, {
+      hydrate: true,
+      container: nextRootElement,
+    });
+  }
+
+  return {
+    renderHTML,
+    render,
+  };
+}

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -8,24 +8,26 @@ export default function makeRenderMethods({
   html: string;
   pageElement: JSX.Element;
 }): {
-  renderHTML: () => void;
-  render: () => HTMLElement;
+  renderHTML: () => { nextRoot: HTMLElement };
+  render: () => { nextRoot: HTMLElement };
 } {
   // Replace the whole document content with SSR html
   function renderHTML() {
     document.documentElement.innerHTML = html;
-  }
-
-  function render() {
-    renderHTML();
-    const nextRootElement = document.getElementById('__next');
-    if (!nextRootElement) {
+    const nextRoot = document.getElementById('__next');
+    if (!nextRoot) {
       throw new Error('[next-page-tester] Missing __next div');
     }
 
+    return { nextRoot };
+  }
+
+  function render() {
+    const { nextRoot } = renderHTML();
+
     // Hydrate page element in existing DOM
-    ReactDOM.hydrate(pageElement, nextRootElement);
-    return nextRootElement;
+    ReactDOM.hydrate(pageElement, nextRoot);
+    return { nextRoot };
   }
 
   return {

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -1,4 +1,4 @@
-import { render as TLRender } from '@testing-library/react';
+import ReactDOM from 'react-dom';
 
 // @TODO: Make this methods overridable via options
 export default function makeRenderMethods({
@@ -7,7 +7,10 @@ export default function makeRenderMethods({
 }: {
   html: string;
   pageElement: JSX.Element;
-}) {
+}): {
+  renderHTML: () => void;
+  render: () => HTMLElement;
+} {
   // Replace the whole document content with SSR html
   function renderHTML() {
     document.documentElement.innerHTML = html;
@@ -21,10 +24,8 @@ export default function makeRenderMethods({
     }
 
     // Hydrate page element in existing DOM
-    TLRender(pageElement, {
-      hydrate: true,
-      container: nextRootElement,
-    });
+    ReactDOM.hydrate(pageElement, nextRootElement);
+    return nextRootElement;
   }
 
   return {

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -11,9 +11,18 @@ export default function makeRenderMethods({
   renderHTML: () => { nextRoot: HTMLElement };
   render: () => { nextRoot: HTMLElement };
 } {
-  // Replace the whole document content with SSR html
+  // Update whole document content with SSR html
+  // @NOTE we have to preserve document.body element identity
+  // to not break @testing-library global "screen" object
   function renderHTML() {
+    const originalBody = document.body;
+
     document.documentElement.innerHTML = html;
+    const bodyContent = document.body.childNodes;
+    originalBody.innerHTML = '';
+    originalBody.append(...bodyContent);
+    document.documentElement.replaceChild(originalBody, document.body);
+
     const nextRoot = document.getElementById('__next');
     if (!nextRoot) {
       throw new Error('[next-page-tester] Missing __next div');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behaviour?

Expose `renderHtml` and `render` methods:

```js
const { renderHTML, render } = await getPage({
```

- `renderHTML ` replaces current DOM with the SSR DOM
- `render` calls `renderHTML ` and hydrate `App` component to `__next` root element

## Does this PR introduce a breaking change?

No.

## Other information:

`render` is currently hydrating using `@testing-library/react`. We might consider replacing it with plain `react-dom/server`'s hydrate().

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
