### PR TITLE
fix: add req.cookies property in "getServerSideProps"

### DIFF
--- a/src/__tests__/cookies/__fixtures__/ssr/pages/authenticated.tsx
+++ b/src/__tests__/cookies/__fixtures__/ssr/pages/authenticated.tsx
@@ -4,9 +4,10 @@ import Link from 'next/link';
 
 type Props = {
   reqHeadersCookie?: string;
+  reqCookies?: object;
 };
 
-export default function Authenticated({ reqHeadersCookie }: Props) {
+export default function Authenticated({ reqHeadersCookie, reqCookies }: Props) {
   return (
     <div>
       <span>Authenticated content</span>
@@ -14,6 +15,7 @@ export default function Authenticated({ reqHeadersCookie }: Props) {
         <a>To login</a>
       </Link>
       <div>req.headers.cookies: "{reqHeadersCookie}"</div>
+      <div>req.cookies: "{JSON.stringify(reqCookies)}"</div>
     </div>
   );
 }
@@ -21,5 +23,10 @@ export default function Authenticated({ reqHeadersCookie }: Props) {
 export const getServerSideProps: GetServerSideProps<Props> = async ({
   req,
 }) => {
-  return { props: { reqHeadersCookie: req.headers.cookie } };
+  return {
+    props: {
+      reqHeadersCookie: req.headers.cookie,
+      reqCookies: req.cookies,
+    },
+  };
 };

--- a/src/__tests__/cookies/__fixtures__/ssr/pages/login.tsx
+++ b/src/__tests__/cookies/__fixtures__/ssr/pages/login.tsx
@@ -4,9 +4,10 @@ import { GetServerSideProps } from 'next';
 
 type Props = {
   reqHeadersCookie?: string;
+  reqCookies?: object;
 };
 
-export default function Login({ reqHeadersCookie }: Props) {
+export default function Login({ reqHeadersCookie, reqCookies }: Props) {
   const router = useRouter();
 
   const handleLogin = () => {
@@ -18,6 +19,7 @@ export default function Login({ reqHeadersCookie }: Props) {
     <div>
       <button onClick={handleLogin}>Login</button>
       <div>req.headers.cookies: "{reqHeadersCookie}"</div>
+      <div>req.cookies: "{JSON.stringify(reqCookies)}"</div>
     </div>
   );
 }
@@ -25,5 +27,10 @@ export default function Login({ reqHeadersCookie }: Props) {
 export const getServerSideProps: GetServerSideProps<Props> = async ({
   req,
 }) => {
-  return { props: { reqHeadersCookie: req.headers.cookie } };
+  return {
+    props: {
+      reqHeadersCookie: req.headers.cookie,
+      reqCookies: req.cookies,
+    },
+  };
 };

--- a/src/__tests__/cookies/cookies.test.tsx
+++ b/src/__tests__/cookies/cookies.test.tsx
@@ -2,6 +2,7 @@ import { getPage } from '../../index';
 import { render, screen } from '@testing-library/react';
 import path from 'path';
 import userEvent from '@testing-library/user-event';
+import { parse } from 'cookie';
 
 describe('cookies', () => {
   describe.each([
@@ -9,6 +10,8 @@ describe('cookies', () => {
     ['getInitialProps', 'gip', ''],
   ])('Page with %s', (dataFetchingType, directory, expectedCookie) => {
     it('Makes document.cookie available via ctx.req.headers.cookie', async () => {
+      const parsedExpectedCookie = parse(expectedCookie);
+
       document.cookie = 'initialCookie=foo';
       const { page } = await getPage({
         nextRoot: path.join(__dirname, '__fixtures__', directory),
@@ -22,10 +25,21 @@ describe('cookies', () => {
 
       await screen.findByText('Authenticated content');
       await screen.findByText(`req.headers.cookies: "${expectedCookie}"`);
+      if (dataFetchingType === 'getServerSideProps') {
+        await screen.findByText(
+          `req.cookies: "${JSON.stringify(parsedExpectedCookie)}"`
+        );
+      }
+
       userEvent.click(screen.getByText('To login'));
 
       await screen.findByText('Login');
       await screen.findByText(`req.headers.cookies: "${expectedCookie}"`);
+      if (dataFetchingType === 'getServerSideProps') {
+        await screen.findByText(
+          `req.cookies: "${JSON.stringify(parsedExpectedCookie)}"`
+        );
+      }
     });
   });
 });

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -4,7 +4,6 @@ import type {
   GetStaticPropsContext,
 } from 'next';
 import type { AppInitialProps } from 'next/app';
-import { parse } from 'cookie';
 import {
   makeGetInitialPropsContext,
   makeGetServerSidePropsContext,
@@ -139,9 +138,6 @@ export default async function fetchPageData({
     const ctx: GetServerSidePropsContext<
       typeof params
     > = makeGetServerSidePropsContext({ options, pageObject });
-    // parsed "cookies" are only available in "getServerSideProps" data fetching method
-    // https://github.com/vercel/next.js/pull/19724/files#diff-f1cccfe490138be7dae0d63562f6a2834af92d21130e0ff10d6de7ad30613f6bR132
-    ctx.req.cookies = parse(ctx.req.headers.cookie || '');
     const pageData = await executeAsIfOnServer(() => getServerSideProps(ctx));
     ensurePageDataHasProps({ pageData });
     return mergePageDataWithAppData({ pageData, appInitialProps });

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -4,6 +4,7 @@ import type {
   GetStaticPropsContext,
 } from 'next';
 import type { AppInitialProps } from 'next/app';
+import { parse } from 'cookie';
 import {
   makeGetInitialPropsContext,
   makeGetServerSidePropsContext,
@@ -138,6 +139,9 @@ export default async function fetchPageData({
     const ctx: GetServerSidePropsContext<
       typeof params
     > = makeGetServerSidePropsContext({ options, pageObject });
+    // parsed "cookies" are only available in "getServerSideProps" data fetching method
+    // https://github.com/vercel/next.js/pull/19724/files#diff-f1cccfe490138be7dae0d63562f6a2834af92d21130e0ff10d6de7ad30613f6bR132
+    ctx.req.cookies = parse(ctx.req.headers.cookie || '');
     const pageData = await executeAsIfOnServer(() => getServerSideProps(ctx));
     ensurePageDataHasProps({ pageData });
     return mergePageDataWithAppData({ pageData, appInitialProps });

--- a/src/fetchData/makeContextObject.ts
+++ b/src/fetchData/makeContextObject.ts
@@ -4,6 +4,7 @@ import type {
   GetServerSidePropsContext,
   GetStaticPropsContext,
 } from 'next';
+import { parse } from 'cookie';
 import makeHttpObjects from './makeHttpObjects';
 import type { ExtendedOptions, PageObject } from '../commonTypes';
 
@@ -58,6 +59,12 @@ export function makeGetServerSidePropsContext({
     resMocker,
     refererRoute: previousRoute,
   });
+
+  // parsed "cookies" are only available in "getServerSideProps" data fetching method
+  // https://github.com/vercel/next.js/pull/19724/files#diff-f1cccfe490138be7dae0d63562f6a2834af92d21130e0ff10d6de7ad30613f6bR132
+  if (req.headers.cookie) {
+    req.cookies = parse(req.headers.cookie);
+  }
 
   // @TODO complete ctx object
   // https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering

--- a/src/fetchData/makeContextObject.ts
+++ b/src/fetchData/makeContextObject.ts
@@ -34,7 +34,6 @@ export function makeGetInitialPropsContext({
       pageObject,
       reqMocker,
       resMocker,
-      appendCookie: true,
       refererRoute: previousRoute,
     });
 
@@ -57,7 +56,6 @@ export function makeGetServerSidePropsContext({
     pageObject,
     reqMocker,
     resMocker,
-    appendCookie: true,
     refererRoute: previousRoute,
   });
 

--- a/src/fetchData/makeHttpObjects.ts
+++ b/src/fetchData/makeHttpObjects.ts
@@ -1,17 +1,16 @@
 import httpMocks from 'node-mocks-http';
 import type { OptionsWithDefaults, PageObject } from '../commonTypes';
+import { parse } from 'cookie';
 
 export default function makeHttpObjects({
   pageObject: { params, route },
   reqMocker,
   resMocker,
-  appendCookie,
   refererRoute,
 }: {
   pageObject: PageObject;
   reqMocker: OptionsWithDefaults['req'];
   resMocker: OptionsWithDefaults['res'];
-  appendCookie?: boolean;
   refererRoute?: string;
 }) {
   const req = httpMocks.createRequest({
@@ -19,9 +18,7 @@ export default function makeHttpObjects({
     params: { ...params },
   });
 
-  // Make document.cookie available in req.headers
-  // @NOTE: SHall we make available req.headers, too?
-  if (appendCookie && document && document.cookie) {
+  if (document && document.cookie) {
     req.headers.cookie = document.cookie;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,12 +15,12 @@ export const executeAsIfOnServer = async <T>(f: () => T) => {
   // @ts-ignore
   delete global.document;
 
-  const result = await f();
-
-  global.window = tmpWindow;
-  global.document = tmpDocument;
-
-  return result;
+  try {
+    return await f();
+  } finally {
+    global.window = tmpWindow;
+    global.document = tmpDocument;
+  }
 };
 
 export const executeAsIfOnServerSync = <T>(f: () => T): T => {
@@ -32,10 +32,10 @@ export const executeAsIfOnServerSync = <T>(f: () => T): T => {
   // @ts-ignore
   delete global.document;
 
-  const result = f();
-
-  global.window = tmpWindow;
-  global.document = tmpDocument;
-
-  return result;
+  try {
+    return f();
+  } finally {
+    global.window = tmpWindow;
+    global.document = tmpDocument;
+  }
 };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix -- add parsed `cookies` property to `GetServerSidePropsContext`. This is available from Next `10.0.4` and was added in this PR: https://github.com/vercel/next.js/pull/19724

## What is the current behaviour?

`req.cookies` are empty in `GetServerSidePropsContext`

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
