### PR TITLE
[next] test migration

### DIFF
--- a/pages/page.js
+++ b/pages/page.js
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default function PagesDiscoveryInRoot() {
-  return <>/auto-pages-directory/in-root/pages/page</>;
+  return <>Page in natural root</>;
 }

--- a/src/__tests__/__utils__/PropsPrinter.tsx
+++ b/src/__tests__/__utils__/PropsPrinter.tsx
@@ -1,6 +1,16 @@
 import React from 'react';
 import { stringify } from './index';
 
-export function PropsPrinter<T extends object>({ props }: { props: T }) {
-  return <>`props: ${stringify(props)}`</>;
+export function PropsPrinter<T extends object>({
+  suppressHydrationWarning,
+  ...props
+}: {
+  suppressHydrationWarning?: boolean;
+  props: T;
+}) {
+  return (
+    <div suppressHydrationWarning={suppressHydrationWarning}>
+      `props: ${stringify(props)}`
+    </div>
+  );
 }

--- a/src/__tests__/__utils__/expectDOMElementsToMatch.ts
+++ b/src/__tests__/__utils__/expectDOMElementsToMatch.ts
@@ -1,17 +1,24 @@
 const REACT_NEW_LINE_COMMENTS_REGEX = /<!-- -->/g;
 const REACT_DATA_REACT_ROOT = / data-reactroot=\"\"/g;
-export function stripReactReactExtraMarkup(string: string): string {
+export function stripReactExtraMarkup(string: string): string {
   return string
     .replace(REACT_NEW_LINE_COMMENTS_REGEX, '')
     .replace(REACT_DATA_REACT_ROOT, '');
 }
 
+/*
+ * Since initial JSDOM dom tree is generated from a html string
+ * created with "ReactDOMServer.renderToString",
+ * dom elements have some extra react-specific extra markup which cause
+ * plain deepEquality assertions to fail.
+ * Here we strip the extra markup before the equality assertion.
+ */
 export function expectDOMElementsToMatch(
   actual: Element,
   expected: Element
 ): void {
-  const actualString = stripReactReactExtraMarkup(actual.outerHTML);
-  const expectedString = stripReactReactExtraMarkup(expected.outerHTML);
+  const actualString = stripReactExtraMarkup(actual.outerHTML);
+  const expectedString = stripReactExtraMarkup(expected.outerHTML);
 
   return expect(actualString).toEqual(expectedString);
 }

--- a/src/__tests__/__utils__/index.ts
+++ b/src/__tests__/__utils__/index.ts
@@ -5,3 +5,5 @@ export { sleep } from './sleep';
 export { stringify } from './stringify';
 export { wrapWithNextRoot } from './wrapWithNextRoot';
 export { expectDOMElementsToMatch } from './expectDOMElementsToMatch';
+export { makeNextRootElement } from './makeNextRootElement';
+export { renderWithinNextRoot } from './renderWithinNextRoot';

--- a/src/__tests__/__utils__/makeNextRootElement.ts
+++ b/src/__tests__/__utils__/makeNextRootElement.ts
@@ -1,0 +1,5 @@
+export function makeNextRootElement(): Element {
+  const root = document.createElement('div');
+  root.id = '__next';
+  return root;
+}

--- a/src/__tests__/__utils__/renderWithinNextRoot.ts
+++ b/src/__tests__/__utils__/renderWithinNextRoot.ts
@@ -1,0 +1,8 @@
+import { render } from '@testing-library/react';
+import { makeNextRootElement } from './index';
+
+export function renderWithinNextRoot(reactElement: JSX.Element) {
+  return render(reactElement, {
+    container: makeNextRootElement(),
+  });
+}

--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render as TLRender, waitFor, screen } from '@testing-library/react';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import PageB from './__fixtures__/pages/b';
 import userEvent from '@testing-library/user-event';
 import type { NextRouter } from 'next/router';
@@ -14,11 +15,11 @@ describe('Client side navigation', () => {
     ${'programmatically'}     | ${'Go to B programmatically'}
   `('$title', ({ linkText }) => {
     it('navigates between pages', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/a',
       });
-      const screen = render(page);
+      const { nextRoot: actual } = render();
       screen.getByText('This is page A');
 
       // Navigate A -> B
@@ -27,8 +28,7 @@ describe('Client side navigation', () => {
       expect(screen.queryByText('This is page A')).not.toBeInTheDocument();
 
       // Ensure router mock update reflects route change
-      const { container: actual } = screen;
-      const { container: expected } = render(
+      const { container: expected } = renderWithinNextRoot(
         <PageB
           routerMock={
             {
@@ -41,15 +41,15 @@ describe('Client side navigation', () => {
           }
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it('GIP navigates between pages ', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: `/gip/a`,
       });
-      render(page);
+      render();
 
       screen.getByText(
         JSON.stringify({
@@ -74,11 +74,11 @@ describe('Client side navigation', () => {
     });
 
     it('SSR navigates between pages ', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: `/ssr/a`,
       });
-      render(page);
+      render();
 
       await screen.findByText(
         JSON.stringify({
@@ -109,7 +109,8 @@ describe('Client side navigation', () => {
       nextRoot,
       route: '/a',
     });
-    const { unmount } = render(page);
+
+    const { unmount } = TLRender(page);
     userEvent.click(screen.getByText('Go to B with Link'));
 
     unmount();

--- a/src/__tests__/cookies/cookies.test.tsx
+++ b/src/__tests__/cookies/cookies.test.tsx
@@ -1,5 +1,5 @@
 import { getPage } from '../../index';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import path from 'path';
 import userEvent from '@testing-library/user-event';
 
@@ -10,11 +10,12 @@ describe('cookies', () => {
   ])('Page with %s', (dataFetchingType, directory, expectedCookie) => {
     it('Makes document.cookie available via ctx.req.headers.cookie', async () => {
       document.cookie = 'initialCookie=foo';
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot: path.join(__dirname, '__fixtures__', directory),
         route: '/login',
       });
-      render(page);
+      render();
+
       // Initial cookie available at first server side render
       screen.getByText('req.headers.cookies: "initialCookie=foo"');
 

--- a/src/__tests__/dynamic-import/dynamic-import.test.tsx
+++ b/src/__tests__/dynamic-import/dynamic-import.test.tsx
@@ -1,14 +1,14 @@
 import { getPage } from '../../index';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import path from 'path';
 
 describe('Dynamic import', () => {
-  it('renders as expected', async () => {
-    const { page } = await getPage({
+  it('renders as expected when client page mounts', async () => {
+    const { render } = await getPage({
       nextRoot: path.join(__dirname, '__fixtures__'),
       route: '/page',
     });
-    render(page);
+    render();
     await screen.findByText('Hello component');
   });
 });

--- a/src/__tests__/global-object/__fixtures__/pages/_document.js
+++ b/src/__tests__/global-object/__fixtures__/pages/_document.js
@@ -20,7 +20,6 @@ class CustomDocument extends Document {
 
   render() {
     const { gip_runTime_window, gip_runTime_document } = this.props;
-
     const component_runTime_window = typeof window !== 'undefined';
     const component_runTime_document = typeof document !== 'undefined';
 

--- a/src/__tests__/global-object/__fixtures__/pages/gip.js
+++ b/src/__tests__/global-object/__fixtures__/pages/gip.js
@@ -12,6 +12,7 @@ export default function gip(props) {
     <>
       <h2>Page</h2>
       <PropsPrinter
+        suppressHydrationWarning={true}
         props={{
           component_importTime_window: importTime_window,
           component_importTime_document: importTime_document,

--- a/src/__tests__/global-object/__fixtures__/pages/page.tsx
+++ b/src/__tests__/global-object/__fixtures__/pages/page.tsx
@@ -5,7 +5,7 @@ export default function Page(props: { [key: string]: any }) {
   return (
     <>
       <h2>Page</h2>
-      <PropsPrinter props={props} />
+      <PropsPrinter suppressHydrationWarning={true} props={props} />
     </>
   );
 }

--- a/src/__tests__/global-object/__fixtures__/pages/ssr.js
+++ b/src/__tests__/global-object/__fixtures__/pages/ssr.js
@@ -12,6 +12,7 @@ export default function ssr(props) {
     <>
       <h2>Page</h2>
       <PropsPrinter
+        suppressHydrationWarning={true}
         props={{
           component_importTime_window: importTime_window,
           component_importTime_document: importTime_document,

--- a/src/__tests__/global-object/app-global-object.test.tsx
+++ b/src/__tests__/global-object/app-global-object.test.tsx
@@ -1,55 +1,76 @@
+import path from 'path';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import Page from './__fixtures__/pages/page';
-import path from 'path';
 
-const expectedGlobals_initial = {
-  component_importTime_window: true,
-  component_importTime_document: true,
-  component_runTime_window: true,
-  component_runTime_document: true,
+const expectedGlobals = {
+  server: {
+    component_importTime_window: false,
+    component_importTime_document: false,
+    component_runTime_window: false,
+    component_runTime_document: false,
 
-  gip_importTime_window: false,
-  gip_importTime_document: false,
-  gip_runTime_window: false,
-  gip_runTime_document: false,
-};
+    gip_importTime_window: false,
+    gip_importTime_document: false,
+    gip_runTime_window: false,
+    gip_runTime_document: false,
+  },
+  initial: {
+    component_importTime_window: true,
+    component_importTime_document: true,
+    component_runTime_window: true,
+    component_runTime_document: true,
 
-const expectedGlobals_clientside = {
-  ...expectedGlobals_initial,
-  gip_importTime_window: true,
-  gip_importTime_document: true,
-  gip_runTime_window: true,
-  gip_runTime_document: true,
+    gip_importTime_window: false,
+    gip_importTime_document: false,
+    gip_runTime_window: false,
+    gip_runTime_document: false,
+  },
+  client: {
+    component_importTime_window: true,
+    component_importTime_document: true,
+    component_runTime_window: true,
+    component_runTime_document: true,
+
+    gip_importTime_window: true,
+    gip_importTime_document: true,
+    gip_runTime_window: true,
+    gip_runTime_document: true,
+  },
 };
 
 describe('Global object', () => {
   describe('_app', () => {
-    describe.each(['initial', 'client'])('%s render', (renderType) => {
-      it("executes app's exports with expected env globals", async () => {
-        const initialRoute = renderType === 'client' ? '/' : '/page';
-        const { page } = await getPage({
-          nextRoot: path.join(__dirname, '__fixtures__'),
-          route: initialRoute,
+    describe.each(['server', 'initial', 'client'])(
+      '%s render',
+      (renderType) => {
+        it("executes app's exports with expected env globals", async () => {
+          const initialRoute = renderType === 'client' ? '/' : '/page';
+          const { render, renderHTML } = await getPage({
+            nextRoot: path.join(__dirname, '__fixtures__'),
+            route: initialRoute,
+          });
+
+          const { nextRoot: actual } =
+            renderType === 'server' ? renderHTML() : render();
+
+          // Client side navigation to SSR page
+          if (renderType === 'client') {
+            userEvent.click(screen.getByText('Go to page'));
+            await screen.findByText('Page');
+          }
+
+          // @ts-ignore
+          const expectedProps = expectedGlobals[renderType];
+          const { container: expected } = renderWithinNextRoot(
+            <Page {...expectedProps} />
+          );
+          expectDOMElementsToMatch(actual, expected);
         });
-        const { container: actual } = render(page);
-
-        // Client side navigation to SSR page
-        if (renderType === 'client') {
-          userEvent.click(screen.getByText('Go to page'));
-          await screen.findByText('Page');
-        }
-
-        const expectedProps =
-          renderType === 'initial'
-            ? expectedGlobals_initial
-            : expectedGlobals_clientside;
-
-        const { container: expected } = render(<Page {...expectedProps} />);
-        expect(actual).toEqual(expected);
-      });
-    });
+      }
+    );
   });
 });

--- a/src/__tests__/global-object/page-global-object.test.tsx
+++ b/src/__tests__/global-object/page-global-object.test.tsx
@@ -1,86 +1,125 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import SSRPage from './__fixtures__/pages/ssr';
 import GIPPage from './__fixtures__/pages/gip';
 import path from 'path';
 
 const expectedGlobals = {
-  component_importTime_window: true,
-  component_importTime_document: true,
-  component_runTime_window: true,
-  component_runTime_document: true,
+  server: {
+    component_importTime_window: false,
+    component_importTime_document: false,
+    component_runTime_window: false,
+    component_runTime_document: false,
 
-  dataFetching_importTime_window: false,
-  dataFetching_importTime_document: false,
-  dataFetching_runTime_window: false,
-  dataFetching_runTime_document: false,
-};
+    dataFetching_importTime_window: false,
+    dataFetching_importTime_document: false,
+    dataFetching_runTime_window: false,
+    dataFetching_runTime_document: false,
+  },
+  initial: {
+    component_importTime_window: true,
+    component_importTime_document: true,
+    component_runTime_window: true,
+    component_runTime_document: true,
 
-const expectedGlobals_GIPClientSide = {
-  ...expectedGlobals,
-  dataFetching_importTime_window: true,
-  dataFetching_importTime_document: true,
-  dataFetching_runTime_window: true,
-  dataFetching_runTime_document: true,
+    dataFetching_importTime_window: false,
+    dataFetching_importTime_document: false,
+    dataFetching_runTime_window: false,
+    dataFetching_runTime_document: false,
+  },
+  client: {
+    component_importTime_window: true,
+    component_importTime_document: true,
+    component_runTime_window: true,
+    component_runTime_document: true,
+
+    dataFetching_importTime_window: false,
+    dataFetching_importTime_document: false,
+    dataFetching_runTime_window: false,
+    dataFetching_runTime_document: false,
+  },
+  clientWithGIP: {
+    component_importTime_window: true,
+    component_importTime_document: true,
+    component_runTime_window: true,
+    component_runTime_document: true,
+
+    dataFetching_importTime_window: true,
+    dataFetching_importTime_document: true,
+    dataFetching_runTime_window: true,
+    dataFetching_runTime_document: true,
+  },
 };
 
 describe('Global object', () => {
   describe('page', () => {
     describe('with getServerSideProps', () => {
-      describe.each(['initial', 'client'])('%s render', (renderType) => {
-        it("executes page's exports with expected env globals", async () => {
-          const initialRoute = renderType === 'client' ? '/' : '/ssr';
-          const { page } = await getPage({
-            nextRoot: path.join(__dirname, '__fixtures__'),
-            route: initialRoute,
-            useApp: false,
+      describe.each(['server', 'initial', 'client'])(
+        '%s render',
+        (renderType) => {
+          it("executes page's exports with expected env globals", async () => {
+            const initialRoute = renderType === 'client' ? '/' : '/ssr';
+            const { renderHTML, render } = await getPage({
+              nextRoot: path.join(__dirname, '__fixtures__'),
+              route: initialRoute,
+              useApp: false,
+            });
+            const { nextRoot: actual } =
+              renderType === 'server' ? renderHTML() : render();
+
+            // Client side navigation to SSR page
+            if (renderType === 'client') {
+              userEvent.click(screen.getByText('Go to SSR'));
+              await screen.findByText('Page');
+            }
+
+            //@ts-ignore
+            const expectedProps = expectedGlobals[renderType];
+            const { container: expected } = renderWithinNextRoot(
+              <SSRPage {...expectedProps} />
+            );
+            expectDOMElementsToMatch(actual, expected);
           });
-          const { container: actual } = render(page);
-
-          // Client side navigation to SSR page
-          if (renderType === 'client') {
-            userEvent.click(screen.getByText('Go to SSR'));
-            await screen.findByText('Page');
-          }
-
-          const expectedProps = expectedGlobals;
-          const { container: expected } = render(
-            <SSRPage {...expectedProps} />
-          );
-          expect(actual).toEqual(expected);
-        });
-      });
+        }
+      );
     });
 
     describe('with getInitialProps', () => {
-      describe.each(['initial', 'client'])('%s render', (renderType) => {
-        it("executes page's exports with expected env globals", async () => {
-          const initialRoute = renderType === 'client' ? '/' : '/gip';
-          const { page } = await getPage({
-            nextRoot: path.join(__dirname, '__fixtures__'),
-            route: initialRoute,
-            useApp: false,
+      describe.each(['server', 'initial', 'client'])(
+        '%s render',
+        (renderType) => {
+          it("executes page's exports with expected env globals", async () => {
+            const initialRoute = renderType === 'client' ? '/' : '/gip';
+            const { renderHTML, render } = await getPage({
+              nextRoot: path.join(__dirname, '__fixtures__'),
+              route: initialRoute,
+              useApp: false,
+            });
+            const { nextRoot: actual } =
+              renderType === 'server' ? renderHTML() : render();
+
+            // Client side navigation to SSR page
+            if (renderType === 'client') {
+              userEvent.click(screen.getByText('Go to GIP'));
+              await screen.findByText('Page');
+            }
+
+            const expectedProps =
+              renderType === 'client'
+                ? expectedGlobals.clientWithGIP
+                : //@ts-ignore
+                  expectedGlobals[renderType];
+
+            const { container: expected } = renderWithinNextRoot(
+              <GIPPage {...expectedProps} />
+            );
+            expectDOMElementsToMatch(actual, expected);
           });
-          const { container: actual } = render(page);
-
-          if (renderType === 'client') {
-            userEvent.click(screen.getByText('Go to GIP'));
-            await screen.findByText('Page');
-          }
-
-          const expectedProps =
-            renderType === 'client'
-              ? expectedGlobals_GIPClientSide
-              : expectedGlobals;
-
-          const { container: expected } = render(
-            <GIPPage {...expectedProps} />
-          );
-          expect(actual).toEqual(expected);
-        });
-      });
+        }
+      );
     });
   });
 });

--- a/src/__tests__/page-data-fetching/page-data-fetching.test.tsx
+++ b/src/__tests__/page-data-fetching/page-data-fetching.test.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
-import { render } from '@testing-library/react';
 import httpMocks from 'node-mocks-http';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import SSRPage from './__fixtures__/pages/ssr/[id]';
 import SSGPage from './__fixtures__/pages/ssg/[id]';
 import GIPPage from './__fixtures__/pages/gip/[id]';
@@ -10,7 +10,7 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Data fetching', () => {
   describe('page with getInitialProps', () => {
     it('feeds page component with returned props', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/gip/5?foo=bar',
       });
@@ -18,7 +18,7 @@ describe('Data fetching', () => {
       const expectedParams = { id: '5' };
       const expectedQuery = { foo: 'bar' };
 
-      const { container: actual } = render(page);
+      const { nextRoot: actual } = render();
       const expectedContext = {
         pathname: '/gip/[id]',
         query: { ...expectedParams, ...expectedQuery },
@@ -33,14 +33,16 @@ describe('Data fetching', () => {
         err: undefined,
       };
 
-      const { container: expected } = render(<GIPPage {...expectedContext} />);
-      expect(actual).toEqual(expected);
+      const { container: expected } = renderWithinNextRoot(
+        <GIPPage {...expectedContext} />
+      );
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
   describe('page with getServerSideProps', () => {
     it('feeds page component with returned props', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/ssr/5?foo=bar',
       });
@@ -48,7 +50,7 @@ describe('Data fetching', () => {
       const expectedParams = { id: '5' };
       const expectedQuery = { foo: 'bar' };
 
-      const { container: actual } = render(page);
+      const { nextRoot: actual } = render();
       const expectedProps = {
         params: expectedParams,
         query: expectedQuery,
@@ -60,26 +62,28 @@ describe('Data fetching', () => {
         }),
         res: httpMocks.createResponse(),
       };
-      const { container: expected } = render(<SSRPage {...expectedProps} />);
-      expect(actual).toEqual(expected);
+      const { container: expected } = renderWithinNextRoot(
+        <SSRPage {...expectedProps} />
+      );
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
   describe('page with getStaticProps', () => {
     it('feeds page component with returned props', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/ssg/5?foo=bar',
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <SSGPage
           params={{
             id: '5',
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 

--- a/src/__tests__/page-extensions/page-extensions.test.tsx
+++ b/src/__tests__/page-extensions/page-extensions.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { getPage } from '../../';
 
 describe('page file extensions', () => {
@@ -6,11 +6,11 @@ describe('page file extensions', () => {
     const nextRoot = __dirname + '/__fixtures__' + '/default-config';
     describe.each(['js', 'jsx', 'ts', 'tsx'])('%s extension', (extension) => {
       it('renders expected page', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot,
           route: `/${extension}`,
         });
-        render(page);
+        render();
         screen.getByText(`${extension} page`);
       });
     });
@@ -33,11 +33,11 @@ describe('page file extensions', () => {
     const nextRoot = __dirname + '/__fixtures__' + '/custom-config';
     describe('allowed extensions', () => {
       it('renders expected page', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot,
           route: '/ts',
         });
-        render(page);
+        render();
         screen.getByText('ts page');
       });
     });

--- a/src/__tests__/pages-discovery/in-root/pages/page.js
+++ b/src/__tests__/pages-discovery/in-root/pages/page.js
@@ -1,3 +1,4 @@
+import React from 'react';
 export default function PagesDiscoveryInRoot() {
-  return `/pages-discovery/in-root/pages/page`;
+  return <>Page in root</>;
 }

--- a/src/__tests__/pages-discovery/in-src/src/pages/page.js
+++ b/src/__tests__/pages-discovery/in-src/src/pages/page.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function PagesDiscoveryInNaturalRoot() {
-  return `/pages/page`;
+  return <>Page in src</>;
 }

--- a/src/__tests__/pages-discovery/pages-discovery.test.tsx
+++ b/src/__tests__/pages-discovery/pages-discovery.test.tsx
@@ -1,45 +1,38 @@
-import React from 'react';
 import path from 'path';
-import { render } from '@testing-library/react';
-import PageInNaturalRoot from '../../../pages/page';
-import PageInRoot from './in-root/pages/page';
-import PageInSrc from './in-src/src/pages/page';
+import { screen } from '@testing-library/react';
 import { getPage } from '../../index';
 
 describe('Pages directory discovery + "nextRoot" option', () => {
   it('discover "pages" directory in auto-detected root', async () => {
-    const { page } = await getPage({
+    const { renderHTML } = await getPage({
       route: '/page',
     });
 
-    const { container: actual } = render(page);
-    const { container: expected } = render(<PageInNaturalRoot />);
-    expect(actual).toEqual(expected);
+    renderHTML();
+    screen.getByText('Page in natural root');
   });
 
   describe('With "nextRoot" option', () => {
     it('discover "pages" directory in provided root', async () => {
       const nextRoot = path.join(__dirname, '/in-root');
-      const { page } = await getPage({
+      const { renderHTML } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      const { container: actual } = render(page);
-      const { container: expected } = render(<PageInRoot />);
-      expect(actual).toEqual(expected);
+      renderHTML();
+      screen.getByText('Page in root');
     });
 
     it('discover "pages" directory in root/src', async () => {
       const nextRoot = path.join(__dirname, '/in-src');
-      const { page } = await getPage({
+      const { renderHTML } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      const { container: actual } = render(page);
-      const { container: expected } = render(<PageInSrc />);
-      expect(actual).toEqual(expected);
+      renderHTML();
+      screen.getByText('Page in src');
     });
 
     describe('"pages" directory not found', () => {

--- a/src/__tests__/referer/referer.test.tsx
+++ b/src/__tests__/referer/referer.test.tsx
@@ -1,5 +1,5 @@
 import { getPage } from '../../index';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import path from 'path';
 import userEvent from '@testing-library/user-event';
 
@@ -8,27 +8,24 @@ describe('referer', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Makes referer available via ctx.req.headers.referer', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/page-a',
         });
-        render(page);
+        render();
         screen.getByText('req.headers.referer: ""');
 
         userEvent.click(screen.getByText('To /page-b'));
-
         await screen.findByText(
           'req.headers.referer: "http://localhost/page-a"'
         );
 
         userEvent.click(screen.getByText('To /page-c'));
-
         await screen.findByText(
           'req.headers.referer: "http://localhost/page-b"'
         );
 
         userEvent.click(screen.getByText('To /page-a'));
-
         await screen.findByText(
           'req.headers.referer: "http://localhost/page-c"'
         );

--- a/src/__tests__/router-mocking/router-mocking.test.tsx
+++ b/src/__tests__/router-mocking/router-mocking.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import WithRouter from './__fixtures__/pages/with-router/[id]';
 
 const nextRoot = __dirname + '/__fixtures__';
@@ -8,13 +8,13 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Router mocking', () => {
   describe('page using "useRouter"', () => {
     it('receives expected router object', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/with-router/99?foo=bar#moo',
       });
 
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <WithRouter
           routerMock={{
             asPath: '/with-router/99?foo=bar#moo',
@@ -28,7 +28,7 @@ describe('Router mocking', () => {
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
@@ -37,17 +37,17 @@ describe('Router mocking', () => {
       const routerMock = {
         route: 'mocked',
       };
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/with-router/99',
         // @ts-ignore
         router: (router) => routerMock,
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <WithRouter routerMock={routerMock} />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 });

--- a/src/__tests__/routing/routing-dynamic-routes.test.tsx
+++ b/src/__tests__/routing/routing-dynamic-routes.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import BlogPage from './__fixtures__/pages/blog/[id]';
 import BlogPage99 from './__fixtures__/pages/blog/99';
 import CatchAllPage from './__fixtures__/pages/catch-all/[id]/[...slug]';
@@ -11,12 +11,12 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Dynamic routes', () => {
   describe('Basic dynamic routes', () => {
     it('gets expected page object', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/blog/5',
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <BlogPage
           routerMock={{
             query: {
@@ -25,16 +25,16 @@ describe('Dynamic routes', () => {
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it('gets expected page object with params and querystring', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/blog/5?foo=bar',
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <BlogPage
           routerMock={{
             query: {
@@ -44,28 +44,28 @@ describe('Dynamic routes', () => {
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it('predefined routes take precedence over dynamic', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/blog/99',
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<BlogPage99 />);
-      expect(actual).toEqual(expected);
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(<BlogPage99 />);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
   describe('Catch all routes', () => {
     it('gets expected page object with params and querystring', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot,
         route: '/catch-all/5/foo/bar/moo?foo=bar',
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <CatchAllPage
           routerMock={{
             query: {
@@ -76,7 +76,7 @@ describe('Dynamic routes', () => {
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it('throws "page not found" error when no optional params are provided', async () => {
@@ -94,12 +94,12 @@ describe('Dynamic routes', () => {
   describe('Optional catch all routes', () => {
     describe('Optional catch all routes', () => {
       it('gets expected page object with params and querystring', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot,
           route: '/optional-catch-all/5/foo/bar/moo?foo=bar',
         });
-        const { container: actual } = render(page);
-        const { container: expected } = render(
+        const { nextRoot: actual } = render();
+        const { container: expected } = renderWithinNextRoot(
           <OptionalCatchAllPage
             routerMock={{
               query: {
@@ -110,16 +110,16 @@ describe('Dynamic routes', () => {
             }}
           />
         );
-        expect(actual).toEqual(expected);
+        expectDOMElementsToMatch(actual, expected);
       });
 
       it('matches when no optional params are provided', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot,
           route: '/optional-catch-all/5',
         });
-        const { container: actual } = render(page);
-        const { container: expected } = render(
+        const { nextRoot: actual } = render();
+        const { container: expected } = renderWithinNextRoot(
           <OptionalCatchAllPage
             routerMock={{
               query: {
@@ -128,7 +128,7 @@ describe('Dynamic routes', () => {
             }}
           />
         );
-        expect(actual).toEqual(expected);
+        expectDOMElementsToMatch(actual, expected);
       });
     });
   });

--- a/src/__tests__/routing/routing-static-routes.test.tsx
+++ b/src/__tests__/routing/routing-static-routes.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { getPage } from '../../';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import IndexPage from './__fixtures__/pages/index';
 import BlogIndexPage from './__fixtures__/pages/blog/index';
 
@@ -9,10 +9,10 @@ const nextRoot = __dirname + '/__fixtures__';
 describe('Static routes', () => {
   describe('route matching a page path', () => {
     it('gets expected component', async () => {
-      const { page } = await getPage({ nextRoot, route: '/index' });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<IndexPage />);
-      expect(actual).toEqual(expected);
+      const { render } = await getPage({ nextRoot, route: '/index' });
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(<IndexPage />);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
@@ -31,10 +31,10 @@ describe('Static routes', () => {
 
   describe('route with trailing slash', () => {
     it('redirect to their counterpart without a trailing slash', async () => {
-      const { page } = await getPage({ nextRoot, route: '/blog/' });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<BlogIndexPage />);
-      expect(actual).toEqual(expected);
+      const { render } = await getPage({ nextRoot, route: '/blog/' });
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(<BlogIndexPage />);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 
@@ -48,17 +48,17 @@ describe('Static routes', () => {
 
   describe('index routes', () => {
     it('routes files named index to the root of the directory', async () => {
-      const { page } = await getPage({ nextRoot, route: '/blog' });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<BlogIndexPage />);
-      expect(actual).toEqual(expected);
+      const { render } = await getPage({ nextRoot, route: '/blog' });
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(<BlogIndexPage />);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it('routes root pages/index page to "/"', async () => {
-      const { page } = await getPage({ nextRoot, route: '/' });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<IndexPage />);
-      expect(actual).toEqual(expected);
+      const { render } = await getPage({ nextRoot, route: '/' });
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(<IndexPage />);
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 

--- a/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
+++ b/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
@@ -1,5 +1,5 @@
 import { getPage } from '../../index';
-import { render, screen } from '@testing-library/react';
+import { getByText, screen } from '@testing-library/react';
 import path from 'path';
 import userEvent from '@testing-library/user-event';
 
@@ -8,12 +8,12 @@ describe('ssr-redirect', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Correctly handles single redirect', async () => {
-        const { page } = await getPage({
+        const { renderHTML } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/proxy-to-page-a',
         });
 
-        render(page);
+        renderHTML();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
     }
@@ -23,12 +23,12 @@ describe('ssr-redirect', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Correctly handles multiple redirects', async () => {
-        const { page } = await getPage({
+        const { renderHTML } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/proxy-page?destination=/proxy-to-page-a',
         });
 
-        render(page);
+        renderHTML();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
     }
@@ -38,12 +38,13 @@ describe('ssr-redirect', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Correctly handles multiple redirects after client side navigation', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/page-b',
         });
 
-        render(page);
+        render();
+
         expect(screen.getByText('Page B')).toBeInTheDocument();
         userEvent.click(screen.getByText('Proxy link'));
 

--- a/src/__tests__/third-party/aws-amplify/aws-amplify.test.ts
+++ b/src/__tests__/third-party/aws-amplify/aws-amplify.test.ts
@@ -1,17 +1,16 @@
 import { getPage } from '../../../index';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 describe('aws-amplify', () => {
   it('should work on server', async () => {
     const error = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
-
-    const { page } = await getPage({
+    const { render } = await getPage({
       nextRoot: __dirname,
       route: '/a',
     });
 
-    render(page);
-    await screen.findByText('The user is not authenticated');
+    render();
+    screen.findByText('The user is not authenticated');
 
     expect(error).toHaveBeenCalledWith(
       expect.stringMatching(/Error: Amplify has not been configured correctly./)

--- a/src/__tests__/use-app/use-app.test.tsx
+++ b/src/__tests__/use-app/use-app.test.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
-import { render } from '@testing-library/react';
 import httpMocks from 'node-mocks-http';
 import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import CustomAppWithGIP from './__fixtures__/custom-app-with-gip/pages/_app';
 import CustomAppWithGIP_AppContextPage from './__fixtures__/custom-app-with-gip/pages/app-context';
 import CustomAppWithGIP_SSRPage from './__fixtures__/custom-app-with-gip/pages/ssr';
@@ -19,11 +19,11 @@ import MissingCustomAppPage from './__fixtures__/missing-custom-app/pages/page';
 describe('_app support', () => {
   describe('_app with getInitialProps', () => {
     it('getInitialProps gets called with expected appContext', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route: '/app-context',
       });
-      const { container: actual } = render(page);
+      const { nextRoot: actual } = render();
       const expectedAppContext = {
         AppTree: Fragment,
         Component: CustomAppWithGIP_AppContextPage,
@@ -47,7 +47,7 @@ describe('_app support', () => {
           basePath: '',
         },
       };
-      const { container: expected } = render(
+      const { container: expected } = renderWithinNextRoot(
         <CustomAppWithGIP
           Component={CustomAppWithGIP_AppContextPage}
           pageProps={{
@@ -55,19 +55,19 @@ describe('_app support', () => {
           }}
         />
       );
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     it.each([
       ['getServerSideProps', '/ssr', CustomAppWithGIP_SSRPage],
       ['getStaticProps', '/ssg', CustomAppWithGIP_SSGPage],
     ])('Page with %s', async (dataFetchingType, route, PageComponent) => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route,
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
         <CustomAppWithGIP
           Component={PageComponent}
           pageProps={{
@@ -78,17 +78,17 @@ describe('_app support', () => {
         />
       );
 
-      expect(actual).toEqual(expected);
+      expectDOMElementsToMatch(actual, expected);
     });
 
     describe('Page with getInitialProps', () => {
       it('getInitialProps does not get called', async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
           route: '/gip',
         });
-        const { container: actual } = render(page);
-        const { container: expected } = render(
+        const { nextRoot: actual } = render();
+        const { container: expected } = renderWithinNextRoot(
           <CustomAppWithGIP
             Component={CustomAppWithGIP_GIPPage}
             pageProps={{
@@ -97,7 +97,7 @@ describe('_app support', () => {
             }}
           />
         );
-        expect(actual).toEqual(expected);
+        expectDOMElementsToMatch(actual, expected);
       });
     });
   });
@@ -105,13 +105,13 @@ describe('_app support', () => {
   describe("calling Next's App.getInitialProps", () => {
     describe('Page with getInitialProps', () => {
       it("App.getInitialProps is able to call page's getInitialProps", async () => {
-        const { page } = await getPage({
+        const { render } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-app-with-next-app-gip',
           route: '/gip',
         });
 
-        const { container: actual } = render(page);
-        const { container: expected } = render(
+        const { nextRoot: actual } = render();
+        const { container: expected } = renderWithinNextRoot(
           <CustomAppWithNextAppGIP
             Component={CustomAppWithNextAppGIP_GIP}
             pageProps={{
@@ -119,31 +119,33 @@ describe('_app support', () => {
             }}
           />
         );
-        expect(actual).toEqual(expected);
+        expectDOMElementsToMatch(actual, expected);
       });
     });
   });
 
   it('Loads custom app file with any extension defined in "next.config.js"', async () => {
-    const { page } = await getPage({
+    const { render } = await getPage({
       nextRoot: __dirname + '/__fixtures__/special-extension',
       route: '/page',
     });
-    const { container: actual } = render(page);
-    const { container: expected } = render(
+    const { nextRoot: actual } = render();
+    const { container: expected } = renderWithinNextRoot(
       <SpecialExtensionCustomApp Component={SpecialExtensionPage} />
     );
-    expect(actual).toEqual(expected);
+    expectDOMElementsToMatch(actual, expected);
   });
 
   it('Return page as usual if no custom app file is found', async () => {
-    const { page } = await getPage({
+    const { render } = await getPage({
       nextRoot: __dirname + '/__fixtures__/missing-custom-app',
       route: '/page',
     });
-    const { container: actual } = render(page);
-    const { container: expected } = render(<MissingCustomAppPage />);
-    expect(actual).toEqual(expected);
+    const { nextRoot: actual } = render();
+    const { container: expected } = renderWithinNextRoot(
+      <MissingCustomAppPage />
+    );
+    expectDOMElementsToMatch(actual, expected);
   });
 
   describe('route matching "_app" page', () => {
@@ -161,14 +163,16 @@ describe('_app support', () => {
 
   describe('"useApp" === false while _app component available', () => {
     it('does not render custom App nor receives props from it', async () => {
-      const { page } = await getPage({
+      const { render } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
         route: '/page',
         useApp: false,
       });
-      const { container: actual } = render(page);
-      const { container: expected } = render(<CustomAppWithGIP_Page />);
-      expect(actual).toEqual(expected);
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
+        <CustomAppWithGIP_Page />
+      );
+      expectDOMElementsToMatch(actual, expected);
     });
   });
 });

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -24,6 +24,8 @@ export default function makeRenderMethods({
     document.documentElement.replaceChild(originalBody, document.body);
 
     const nextRoot = document.getElementById('__next');
+
+    /* istanbul ignore next */
     if (!nextRoot) {
       throw new Error('[next-page-tester] Missing __next div');
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test update

## What is the current behaviour?

Current tests retrieve `page` element from `getPage` return object and render it with `@testinbn-library/react`

## What is the new behaviour?

Since we're considering switching to a new render strategy based on pre-render SSR html in JSDOM and then mount `page` element into it with a `hydrate` call (using `render` or `renderHTML` methods), tests should be rewritten to adhere to the new testing flow.

## Does this PR introduce a breaking change?

No, but it's part of a wider breaking change.

## Other information:

The migration is still ongoing...

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
