### PR TITLE
[next] Render root html element attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,18 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "htmlparser2": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
+          "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.3.0",
+            "domutils": "^2.4.2",
+            "entities": "^2.0.0"
+          }
+        },
         "postcss": {
           "version": "7.0.32",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
@@ -4026,6 +4038,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
@@ -4390,11 +4412,21 @@
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.5.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "chownr": {
@@ -5901,9 +5933,9 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.5.tgz",
-      "integrity": "sha512-lEvThd1Xq+CCylf1n+05bUZCDZjTufaaaqpxM3JZ+4iDqtlG+d/oKgtMmg9GEMOuzBgUoalIzFOaClht9YiGJQ==",
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.6.tgz",
+      "integrity": "sha512-40WHI/5d2MOzf1sD2bSaTXlPn1lueJLAX6j1xH5dSAr6tNeut8B9ktEL6sjAK9yVON4uNj9//axOdBJUuruCzw==",
       "dev": true
     },
     "fastq": {
@@ -5937,6 +5969,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -6304,6 +6343,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6641,18 +6687,6 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
-    },
-    "htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
-        "entities": "^2.0.0"
-      }
     },
     "http-errors": {
       "version": "1.7.3",
@@ -7465,6 +7499,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -8640,6 +8675,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -12345,6 +12387,7 @@
             "anymatch": "^2.0.0",
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
             "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
@@ -12378,6 +12421,17 @@
                 "is-extendable": "^0.1.0"
               }
             }
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
           }
         },
         "glob-parent": {

--- a/src/__tests__/real-world-example/real-world-example.test.tsx
+++ b/src/__tests__/real-world-example/real-world-example.test.tsx
@@ -12,9 +12,8 @@ describe('real-world-example', () => {
     });
     render();
 
-    // @TODO Uncomment these lines when renderHTML will update html element attributes
-    // const html = document.documentElement;
-    // expect(html).toHaveAttribute('lang', 'en');
+    const html = document.documentElement;
+    expect(html).toHaveAttribute('lang', 'en');
 
     const head = document.querySelector('head') as HTMLHeadElement;
     expect(head.querySelector('meta[name="Description"]')).toHaveAttribute(

--- a/src/__tests__/use-document/use-document.test.tsx
+++ b/src/__tests__/use-document/use-document.test.tsx
@@ -19,9 +19,8 @@ describe('_document support', () => {
         });
         renderHTML();
 
-        // @TODO Uncomment these lines when renderHTML will update html element attributes
-        // const html = document.documentElement as HTMLHtmlElement;
-        // expect(html).toHaveAttribute('lang', 'en');
+        const html = document.documentElement;
+        expect(html).toHaveAttribute('lang', 'en');
 
         const actual = document.querySelector('#__next') as HTMLDivElement;
         actual.removeAttribute('id');
@@ -91,10 +90,6 @@ describe('_document support', () => {
           useDocument: true,
         });
         render();
-
-        // @TODO Uncomment these lines when renderHTML will update html element attributes
-        // const html = document.documentElement as HTMLHtmlElement;
-        // expect(html).toHaveAttribute('lang', 'en');
 
         screen.getByText('Count: 0');
         userEvent.click(screen.getByText('Count me!'));

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -12,19 +12,23 @@ export function makeRenderMethods({
   render: () => { nextRoot: HTMLElement };
 } {
   // Update whole document content with SSR html
-  // @NOTE we have to preserve document.body element identity
-  // to not break @testing-library global "screen" object
-
-  // @TODO: Update html element attributes
   function renderHTML() {
     const originalBody = document.body;
-    document.documentElement.innerHTML = html;
+    const domParser = new DOMParser();
+    const newDocument = domParser.parseFromString(html, 'text/html');
+    document.replaceChild(
+      newDocument.documentElement,
+      document.documentElement
+    );
+
+    // Replace new body element with original one
+    // @NOTE we have to preserve document.body element identity
+    // to not break @testing-library global "screen" object
     const bodyContent = document.body.childNodes;
     originalBody.append(...bodyContent);
     document.documentElement.replaceChild(originalBody, document.body);
 
     const nextRoot = document.getElementById('__next');
-
     /* istanbul ignore next */
     if (!nextRoot) {
       throw new Error('[next-page-tester] Missing __next div');
@@ -51,6 +55,7 @@ export function cleanup() {
   document.body.innerHTML = '';
   document.head.innerHTML = '';
 
+  // Cleanup html root element attributes
   const html = document.documentElement;
   while (html.attributes.length > 0) {
     html.removeAttribute(html.attributes[0].name);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

JSDOM root `html` element is not updated with `html` attributes returned from SSR render (this should happen in `renderHTML`)

## What is the new behaviour?

Parse the `html` string with an XML parsee, retrieve `html` elements attribute and manually append them to JSDOM `html` element.

## Other information:

Using an XML parser to get these few attributes seems overkill, but I haven't been able to find a better way to update JSDOM `html` root element attributes.

@Meemaw if a simpler solution came to your mind, I'm all ears. I feel like there has to be a better way, but...

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
