### PR TITLE
[next] Rename return object

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ const { render, serverRender, html, page } = await getPage({ options });
 
 ### render()
 
-Type: `() => HTMLElement<NextRoot>`<br/>
+Type: `() => { nextRoot: HTMLElement<NextRoot> }`<br/>
 Returns: `#__next` root element element.
 
 Unless you have an advanced use-case, you should mostly use this method. Under the hood it calls `serverRender()` and then mounts/hydrates the React application into JSDOM `#__next` root element. This is what users would get/see when they visit a page.
 
 ### serverRender()
 
-Type: `() => HTMLElement<NextRoot>`<br/>
+Type: `() => { nextRoot: HTMLElement<NextRoot> }`<br/>
 Returns: `#__next` root element element.
 
 Inject the output of server side rendering into the DOM and doesn't mount React. Use it to test how Next.js renders in the following scenarios:
@@ -78,11 +78,11 @@ Inject the output of server side rendering into the DOM and doesn't mount React.
 - when JS is disabled
 - SEO tests
 
-### html
+### serverRenderToString()
 
-Type: `string`
+Type: `() => { html: string }`
 
-HTML string representing output of server side rendering.
+`html` is the HTML string representing output of server side rendering.
 
 ### page
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Unless you have an advanced use-case, you should mostly use this method. Under t
 Type: `() => { nextRoot: HTMLElement<NextRoot> }`<br/>
 Returns: `#__next` root element element.
 
-Inject the output of server side rendering into the DOM and doesn't mount React. Use it to test how Next.js renders in the following scenarios:
+Inject the output of server side rendering into the DOM but doesn't mount React. Use it to test how Next.js renders in the following scenarios:
 
 - before Reacts mounts
 - when JS is disabled
@@ -82,7 +82,7 @@ Inject the output of server side rendering into the DOM and doesn't mount React.
 
 Type: `() => { html: string }`
 
-`html` is the HTML string representing output of server side rendering.
+Render the output of server side rendering as HTML string. This is a pure method without side-effects.
 
 ### page
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The mounted application is **interactive** and can be tested with any DOM testin
 
 ```js
 import { getPage } from 'next-page-tester';
-const { render, renderHTML, html, page } = await getPage({ options });
+const { render, serverRender, html, page } = await getPage({ options });
 ```
 
 ### render()
@@ -65,9 +65,9 @@ const { render, renderHTML, html, page } = await getPage({ options });
 Type: `() => HTMLElement<NextRoot>`<br/>
 Returns: `#__next` root element element.
 
-Unless you have an advanced use-case, you should mostly use this method. Under the hood it calls `renderHTML()` and then mounts/hydrates the React application into JSDOM `#__next` root element. This is what users would get/see when they visit a page.
+Unless you have an advanced use-case, you should mostly use this method. Under the hood it calls `serverRender()` and then mounts/hydrates the React application into JSDOM `#__next` root element. This is what users would get/see when they visit a page.
 
-### renderHTML()
+### serverRender()
 
 Type: `() => HTMLElement<NextRoot>`<br/>
 Returns: `#__next` root element element.

--- a/src/__tests__/get-page-return/get-page-return.test.tsx
+++ b/src/__tests__/get-page-return/get-page-return.test.tsx
@@ -32,13 +32,13 @@ describe('getPage() return', () => {
     });
   });
 
-  describe('renderHTML', () => {
+  describe('serverRender', () => {
     it('append to DOM expected elements', async () => {
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         nextRoot: path.join(__dirname, '__fixtures__'),
         route: '/page',
       });
-      const { nextRoot } = renderHTML();
+      const { nextRoot } = serverRender();
       const actualNextRoot = document.getElementById('__next');
       expect(nextRoot).toBe(actualNextRoot);
 
@@ -62,11 +62,11 @@ describe('getPage() return', () => {
 
     it('preserves existing body element', async () => {
       const initialBody = document.body;
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         nextRoot: path.join(__dirname, '__fixtures__'),
         route: '/page',
       });
-      renderHTML();
+      serverRender();
       expect(initialBody).toBe(document.body);
     });
   });

--- a/src/__tests__/get-page-return/get-page-return.test.tsx
+++ b/src/__tests__/get-page-return/get-page-return.test.tsx
@@ -10,12 +10,13 @@ import { expectDOMElementsToMatch } from '../__utils__';
 // @NOTE These tests are not extensive.
 // They provide a rough idea of the values returned by getPage
 describe('getPage() return', () => {
-  describe('html', () => {
-    it("is an HTML string representing the apps's SSR output", async () => {
-      const { html } = await getPage({
+  describe('serverRenderToString', () => {
+    it("returns HTML string representing the apps's SSR output", async () => {
+      const { serverRenderToString } = await getPage({
         nextRoot: path.join(__dirname, '__fixtures__'),
         route: '/page',
       });
+      const { html } = serverRenderToString();
 
       const expectedPage = (
         <html>

--- a/src/__tests__/global-object/app-global-object.test.tsx
+++ b/src/__tests__/global-object/app-global-object.test.tsx
@@ -49,13 +49,13 @@ describe('Global object', () => {
       (renderType) => {
         it("executes app's exports with expected env globals", async () => {
           const initialRoute = renderType === 'client' ? '/' : '/page';
-          const { render, renderHTML } = await getPage({
+          const { render, serverRender } = await getPage({
             nextRoot: path.join(__dirname, '__fixtures__'),
             route: initialRoute,
           });
 
           const { nextRoot: actual } =
-            renderType === 'server' ? renderHTML() : render();
+            renderType === 'server' ? serverRender() : render();
 
           // Client side navigation to SSR page
           if (renderType === 'client') {

--- a/src/__tests__/global-object/document-global-object.test.tsx
+++ b/src/__tests__/global-object/document-global-object.test.tsx
@@ -11,13 +11,13 @@ describe('Global object', () => {
       (renderType) => {
         it("executes page's exports with expected env globals", async () => {
           const initialRoute = renderType === 'client' ? '/' : '/ssr';
-          const { renderHTML, render } = await getPage({
+          const { serverRender, render } = await getPage({
             nextRoot: path.join(__dirname, '__fixtures__'),
             route: initialRoute,
             useDocument: true,
           });
 
-          renderType === 'server' ? renderHTML() : render();
+          renderType === 'server' ? serverRender() : render();
 
           // Client side navigation to SSR page
           if (renderType === 'client') {

--- a/src/__tests__/global-object/page-global-object.test.tsx
+++ b/src/__tests__/global-object/page-global-object.test.tsx
@@ -62,13 +62,13 @@ describe('Global object', () => {
         (renderType) => {
           it("executes page's exports with expected env globals", async () => {
             const initialRoute = renderType === 'client' ? '/' : '/ssr';
-            const { renderHTML, render } = await getPage({
+            const { serverRender, render } = await getPage({
               nextRoot: path.join(__dirname, '__fixtures__'),
               route: initialRoute,
               useApp: false,
             });
             const { nextRoot: actual } =
-              renderType === 'server' ? renderHTML() : render();
+              renderType === 'server' ? serverRender() : render();
 
             // Client side navigation to SSR page
             if (renderType === 'client') {
@@ -93,13 +93,13 @@ describe('Global object', () => {
         (renderType) => {
           it("executes page's exports with expected env globals", async () => {
             const initialRoute = renderType === 'client' ? '/' : '/gip';
-            const { renderHTML, render } = await getPage({
+            const { serverRender, render } = await getPage({
               nextRoot: path.join(__dirname, '__fixtures__'),
               route: initialRoute,
               useApp: false,
             });
             const { nextRoot: actual } =
-              renderType === 'server' ? renderHTML() : render();
+              renderType === 'server' ? serverRender() : render();
 
             // Client side navigation to SSR page
             if (renderType === 'client') {

--- a/src/__tests__/pages-discovery/pages-discovery.test.tsx
+++ b/src/__tests__/pages-discovery/pages-discovery.test.tsx
@@ -4,34 +4,34 @@ import { getPage } from '../../index';
 
 describe('Pages directory discovery + "nextRoot" option', () => {
   it('discover "pages" directory in auto-detected root', async () => {
-    const { renderHTML } = await getPage({
+    const { serverRender } = await getPage({
       route: '/page',
     });
 
-    renderHTML();
+    serverRender();
     screen.getByText('Page in natural root');
   });
 
   describe('With "nextRoot" option', () => {
     it('discover "pages" directory in provided root', async () => {
       const nextRoot = path.join(__dirname, '/in-root');
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      renderHTML();
+      serverRender();
       screen.getByText('Page in root');
     });
 
     it('discover "pages" directory in root/src', async () => {
       const nextRoot = path.join(__dirname, '/in-src');
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         route: '/page',
         nextRoot,
       });
 
-      renderHTML();
+      serverRender();
       screen.getByText('Page in src');
     });
 

--- a/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
+++ b/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
@@ -8,12 +8,12 @@ describe('ssr-redirect', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Correctly handles single redirect', async () => {
-        const { renderHTML } = await getPage({
+        const { serverRender } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/proxy-to-page-a',
         });
 
-        renderHTML();
+        serverRender();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
     }
@@ -23,12 +23,12 @@ describe('ssr-redirect', () => {
     'Page with %s',
     (_dataFetchingType, directory) => {
       it('Correctly handles multiple redirects', async () => {
-        const { renderHTML } = await getPage({
+        const { serverRender } = await getPage({
           nextRoot: path.join(__dirname, '__fixtures__', directory),
           route: '/proxy-page?destination=/proxy-to-page-a',
         });
 
-        renderHTML();
+        serverRender();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
     }

--- a/src/__tests__/use-document/use-document.test.tsx
+++ b/src/__tests__/use-document/use-document.test.tsx
@@ -12,13 +12,12 @@ describe('_document support', () => {
   describe('_document with getInitialProps', () => {
     describe('with custom _app', () => {
       it('renders page wrapped in custom _app wrapped in _document', async () => {
-        const { renderHTML } = await getPage({
+        const { serverRender } = await getPage({
           nextRoot: __dirname + '/__fixtures__/custom-document-with-gip',
           route: '/page',
           useDocument: true,
         });
-        const { nextRoot: actual } = renderHTML();
-
+        const { nextRoot: actual } = serverRender();
         const html = document.documentElement;
         expect(html).toHaveAttribute('lang', 'en');
 
@@ -34,12 +33,12 @@ describe('_document support', () => {
   describe('_document with special extensions', () => {
     it('renders expected document component', async () => {
       const route = '/page';
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         nextRoot: __dirname + '/__fixtures__/special-extension',
         route,
         useDocument: true,
       });
-      renderHTML();
+      serverRender();
 
       const metaDescriptions = getMetaTagsContentByName(
         document.documentElement,
@@ -51,12 +50,12 @@ describe('_document support', () => {
 
   describe('useCustomDocument === false', () => {
     it('renders default empty document', async () => {
-      const { renderHTML } = await getPage({
+      const { serverRender } = await getPage({
         nextRoot: __dirname + '/__fixtures__/custom-document-with-gip',
         route: '/page',
         useDocument: false,
       });
-      renderHTML();
+      serverRender();
 
       const actual = document.documentElement;
       const { container: expected } = render(
@@ -99,7 +98,7 @@ describe('_document support', () => {
   describe('next/document Head and next/head', () => {
     describe('SSR render', () => {
       it('merges _document and page head elements', async () => {
-        const { renderHTML } = await getPage({
+        const { serverRender } = await getPage({
           nextRoot: path.join(
             __dirname,
             '/__fixtures__/custom-document-with-gip'
@@ -107,7 +106,7 @@ describe('_document support', () => {
           route: '/page',
           useDocument: true,
         });
-        renderHTML();
+        serverRender();
 
         const metaDescriptions = getMetaTagsContentByName(
           document.documentElement,

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -8,11 +8,11 @@ export function makeRenderMethods({
   html: string;
   pageElement: JSX.Element;
 }): {
-  renderHTML: () => { nextRoot: HTMLElement };
+  serverRender: () => { nextRoot: HTMLElement };
   render: () => { nextRoot: HTMLElement };
 } {
   // Update whole document content with SSR html
-  function renderHTML() {
+  function serverRender() {
     const originalBody = document.body;
     const domParser = new DOMParser();
     const newDocument = domParser.parseFromString(html, 'text/html');
@@ -38,7 +38,7 @@ export function makeRenderMethods({
   }
 
   function render() {
-    const { nextRoot } = renderHTML();
+    const { nextRoot } = serverRender();
 
     // Hydrate page element in existing DOM
     ReactDOM.hydrate(pageElement, nextRoot);
@@ -46,7 +46,7 @@ export function makeRenderMethods({
   }
 
   return {
-    renderHTML,
+    serverRender,
     render,
   };
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the new behaviour?

Rename `getPage` return values.

Current API:

```js
const { render, renderHTML, html, page } = await getPage({ options });
```

New API:

```js
const { render, serverRender, serverRenderToString, page } = await getPage({ options });
```

## Does this PR introduce a breaking change?

Yes.

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
