### PR TITLE
refactor: uniform error messages

### DIFF
--- a/src/RouterProvider.tsx
+++ b/src/RouterProvider.tsx
@@ -41,7 +41,7 @@ export default function RouterProvider({
       setState({ router: nextRouter, children: pageElement });
     } else {
       console.warn(
-        `[next-page-tester]: Un-awaited client side navigation from "${previousRoute}" to "${nextRoute}". This might lead into unexpected bugs and errors.`
+        `[next-page-tester] Un-awaited client side navigation from "${previousRoute}" to "${nextRoute}". This might lead into unexpected bugs and errors.`
       );
     }
   }, []);

--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -117,7 +117,7 @@ describe('Client side navigation', () => {
 
     await waitFor(() => {
       expect(warn).toHaveBeenCalledWith(
-        '[next-page-tester]: Un-awaited client side navigation from "/a" to "/b". This might lead into unexpected bugs and errors.'
+        '[next-page-tester] Un-awaited client side navigation from "/a" to "/b". This might lead into unexpected bugs and errors.'
       );
     });
 

--- a/src/__tests__/no-default-export/no-default-export.test.ts
+++ b/src/__tests__/no-default-export/no-default-export.test.ts
@@ -9,7 +9,7 @@ describe('no-default-export', () => {
         route: '/a',
       })
     ).rejects.toThrow(
-      '[next-page-tester]: No default export found for given route'
+      '[next-page-tester] No default export found for given route'
     );
   });
 });

--- a/src/__tests__/options-errors-handling.test.ts
+++ b/src/__tests__/options-errors-handling.test.ts
@@ -9,7 +9,9 @@ describe('Options errors handling', () => {
           nextRoot,
           route: 'blog',
         })
-      ).rejects.toThrow('[next page tester] "route" option should start');
+      ).rejects.toThrow(
+        '[next-page-tester] "route" option should start with "/"'
+      );
     });
   });
 
@@ -20,7 +22,7 @@ describe('Options errors handling', () => {
           nextRoot: 'doesnt-exist',
           route: '/page',
         })
-      ).rejects.toThrow('[next page tester] Cannot find "nextRoot" directory');
+      ).rejects.toThrow('[next-page-tester] Cannot find "nextRoot" directory');
     });
   });
 });

--- a/src/__tests__/page-data-fetching/page-data-fetching-special-returns.test.tsx
+++ b/src/__tests__/page-data-fetching/page-data-fetching-special-returns.test.tsx
@@ -8,7 +8,7 @@ describe('Data fetching with special return types', () => {
     it('throws "missing prop field" error when not-found object is returned', async () => {
       const returnObject = await NotFoundPage.getServerSideProps();
       const expectedError: CustomError = new Error(
-        `[next page tester] Page's fetching method returned an object with unsupported fields. Supported fields are: \"[props, redirect]\". Returned value is available in error.payload.`
+        `[next-page-tester] Page's fetching method returned an object with unsupported fields. Supported fields are: \"[props, redirect]\". Returned value is available in error.payload.`
       );
       expectedError.payload = returnObject;
 

--- a/src/__tests__/page-data-fetching/page-data-fetching.test.tsx
+++ b/src/__tests__/page-data-fetching/page-data-fetching.test.tsx
@@ -95,7 +95,7 @@ describe('Data fetching', () => {
           route: '/multiple-data-fetching',
         })
       ).rejects.toThrow(
-        '[next page tester] Only one data fetching method is allowed'
+        '[next-page-tester] Only one data fetching method is allowed'
       );
     });
   });

--- a/src/__tests__/page-extensions/page-extensions.test.tsx
+++ b/src/__tests__/page-extensions/page-extensions.test.tsx
@@ -23,7 +23,7 @@ describe('page file extensions', () => {
             route: '/invalid',
           })
         ).rejects.toThrow(
-          '[next page tester] No matching page found for given route'
+          '[next-page-tester] No matching page found for given route'
         );
       });
     });
@@ -49,7 +49,7 @@ describe('page file extensions', () => {
             route: '/js',
           })
         ).rejects.toThrow(
-          '[next page tester] No matching page found for given route'
+          '[next-page-tester] No matching page found for given route'
         );
       });
     });

--- a/src/__tests__/pages-discovery/pages-discovery.test.tsx
+++ b/src/__tests__/pages-discovery/pages-discovery.test.tsx
@@ -42,7 +42,7 @@ describe('Pages directory discovery + "nextRoot" option', () => {
             nextRoot: __dirname,
             route: '/page',
           })
-        ).rejects.toThrow('[next page tester] Cannot find "pages" directory');
+        ).rejects.toThrow('[next-page-tester] Cannot find "pages" directory');
       });
     });
   });

--- a/src/__tests__/routing/routing-dynamic-routes.test.tsx
+++ b/src/__tests__/routing/routing-dynamic-routes.test.tsx
@@ -86,7 +86,7 @@ describe('Dynamic routes', () => {
           route: '/catch-all/5',
         })
       ).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
+        '[next-page-tester] No matching page found for given route'
       );
     });
   });

--- a/src/__tests__/routing/routing-static-routes.test.tsx
+++ b/src/__tests__/routing/routing-static-routes.test.tsx
@@ -24,7 +24,7 @@ describe('Static routes', () => {
           route: '/blog/5/doesntexists',
         })
       ).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
+        '[next-page-tester] No matching page found for given route'
       );
     });
   });
@@ -41,7 +41,7 @@ describe('Static routes', () => {
   describe('route === "_document"', () => {
     it('throws "page not found" error', async () => {
       await expect(getPage({ nextRoot, route: '/_document' })).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
+        '[next-page-tester] No matching page found for given route'
       );
     });
   });
@@ -70,7 +70,7 @@ describe('Static routes', () => {
           route: '/api',
         })
       ).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
+        '[next-page-tester] No matching page found for given route'
       );
     });
   });

--- a/src/__tests__/use-app/use-app.test.tsx
+++ b/src/__tests__/use-app/use-app.test.tsx
@@ -156,7 +156,7 @@ describe('_app support', () => {
           route: '/_app',
         })
       ).rejects.toThrow(
-        '[next page tester] No matching page found for given route'
+        '[next-page-tester] No matching page found for given route'
       );
     });
   });

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -35,7 +35,7 @@ function ensureNoMultipleDataFetchingMethods({
   }
   if (methodsCounter > 1) {
     throw new Error(
-      '[next page tester] Only one data fetching method is allowed'
+      '[next-page-tester] Only one data fetching method is allowed'
     );
   }
 }
@@ -53,7 +53,7 @@ function ensurePageDataHasProps({
     }
   }
 
-  const errorMessage = `[next page tester] Page's fetching method returned an object with unsupported fields. Supported fields are: "[${allowedKeys.join(
+  const errorMessage = `[next-page-tester] Page's fetching method returned an object with unsupported fields. Supported fields are: "[${allowedKeys.join(
     ', '
   )}]". Returned value is available in error.payload.`;
   const error: CustomError = new Error(errorMessage);

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -21,12 +21,12 @@ import type {
 
 function validateOptions({ nextRoot, route }: OptionsWithDefaults) {
   if (!route.startsWith('/')) {
-    throw new Error('[next page tester] "route" option should start with "/"');
+    throw new Error('[next-page-tester] "route" option should start with "/"');
   }
 
   if (!existsSync(nextRoot)) {
     throw new Error(
-      '[next page tester] Cannot find "nextRoot" directory under: ${nextRoot}'
+      '[next-page-tester] Cannot find "nextRoot" directory under: ${nextRoot}'
     );
   }
 }

--- a/src/getPageObject.ts
+++ b/src/getPageObject.ts
@@ -24,13 +24,13 @@ export default async function getPageObject({
 
     if (!page.client.default) {
       throw new Error(
-        '[next-page-tester]: No default export found for given route'
+        '[next-page-tester] No default export found for given route'
       );
     }
     const appFile = getAppFile({ options });
     return { page, appFile, ...pageInfo };
   }
-  throw new Error('[next page tester] No matching page found for given route');
+  throw new Error('[next-page-tester] No matching page found for given route');
 }
 
 type RegexCaptureGroups =

--- a/src/loadPage.ts
+++ b/src/loadPage.ts
@@ -33,7 +33,7 @@ export function loadPage<FileType>({
   }
 
   throw new Error(
-    "[next page tester] Couldn't find required page file with matching extension"
+    "[next-page-tester] Couldn't find required page file with matching extension"
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,7 @@ export function findPagesDirectory({ nextRoot }: { nextRoot: string }) {
   }
 
   throw new Error(
-    `[next page tester] Cannot find "pages" directory under: ${nextRoot}`
+    `[next-page-tester] Cannot find "pages" directory under: ${nextRoot}`
   );
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor 

## What is the current behaviour?

Error messages throw non uniform error messages

## What is the new behaviour?

Error messages comply with following template: `[next-page-tester] Error message`

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
