### PR TITLE
feat: catch errors & render _error page

### DIFF
--- a/src/__tests__/_error/__fixtures__/with-custom-error/gip/pages/_error.tsx
+++ b/src/__tests__/_error/__fixtures__/with-custom-error/gip/pages/_error.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ErrorProps } from 'next/error';
+
+type Props = ErrorProps;
+
+export default function CustomError({ statusCode }: Props) {
+  return (
+    <p>
+      [CustomError] It looks like we have some problems. Status: {statusCode}
+    </p>
+  );
+}

--- a/src/__tests__/_error/__fixtures__/with-custom-error/gip/pages/a.tsx
+++ b/src/__tests__/_error/__fixtures__/with-custom-error/gip/pages/a.tsx
@@ -1,0 +1,7 @@
+export default function PageA() {
+  return null;
+}
+
+PageA.getInitialProps = function () {
+  throw new Error('Something went wrong!');
+};

--- a/src/__tests__/_error/__fixtures__/with-custom-error/ssr/pages/_error.tsx
+++ b/src/__tests__/_error/__fixtures__/with-custom-error/ssr/pages/_error.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ErrorProps } from 'next/error';
+
+type Props = ErrorProps;
+
+export default function CustomError({ statusCode }: Props) {
+  return (
+    <p>
+      [CustomError] It looks like we have some problems. Status: {statusCode}
+    </p>
+  );
+}

--- a/src/__tests__/_error/__fixtures__/with-custom-error/ssr/pages/a.tsx
+++ b/src/__tests__/_error/__fixtures__/with-custom-error/ssr/pages/a.tsx
@@ -1,0 +1,9 @@
+import type { GetServerSideProps } from 'next';
+
+export default function PageA() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  throw new Error('Something went wrong!');
+};

--- a/src/__tests__/_error/__fixtures__/with-default-error/gip/pages/a.tsx
+++ b/src/__tests__/_error/__fixtures__/with-default-error/gip/pages/a.tsx
@@ -1,0 +1,7 @@
+export default function PageA() {
+  return null;
+}
+
+PageA.getInitialProps = function () {
+  throw new Error('Something went wrong!');
+};

--- a/src/__tests__/_error/__fixtures__/with-default-error/ssr/pages/a.tsx
+++ b/src/__tests__/_error/__fixtures__/with-default-error/ssr/pages/a.tsx
@@ -1,0 +1,9 @@
+import type { GetServerSideProps } from 'next';
+
+export default function PageA() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  throw new Error('Something went wrong!');
+};

--- a/src/__tests__/_error/_error.test.ts
+++ b/src/__tests__/_error/_error.test.ts
@@ -1,0 +1,93 @@
+import path from 'path';
+import { screen } from '@testing-library/react';
+import { getPage } from '../../index';
+
+describe('_error support', () => {
+  describe('with-default-error', () => {
+    describe.each([['ssr'], ['gip']])(
+      '%s page with-default-error',
+      (dataFetchingMethod) => {
+        it('Correctly renders 500 error', async () => {
+          const { render } = await getPage({
+            nextRoot: path.join(
+              __dirname,
+              '__fixtures__',
+              'with-default-error',
+              dataFetchingMethod
+            ),
+            route: '/a',
+          });
+          render();
+
+          expect(
+            screen.getByText('Internal Server Error.')
+          ).toBeInTheDocument();
+          expect(screen.getByText('500')).toBeInTheDocument();
+        });
+
+        it('Correctly renders 404 error', async () => {
+          const { render } = await getPage({
+            nextRoot: path.join(
+              __dirname,
+              '__fixtures__',
+              'with-default-error',
+              dataFetchingMethod
+            ),
+            route: '/random',
+          });
+
+          render();
+          expect(
+            screen.getByText('This page could not be found.')
+          ).toBeInTheDocument();
+          expect(screen.getByText('404')).toBeInTheDocument();
+        });
+      }
+    );
+  });
+
+  describe('with-custom-error', () => {
+    describe.each([['ssr'], ['gip']])(
+      '%s page with-custom-error',
+      (dataFetchingMethod) => {
+        it('Correctly renders 500 _error page', async () => {
+          const { render } = await getPage({
+            nextRoot: path.join(
+              __dirname,
+              '__fixtures__',
+              'with-custom-error',
+              dataFetchingMethod
+            ),
+            route: '/a',
+          });
+
+          render();
+          expect(
+            screen.getByText(
+              '[CustomError] It looks like we have some problems. Status: 500'
+            )
+          ).toBeInTheDocument();
+        });
+
+        it('Correctly renders 404 error', async () => {
+          const { render } = await getPage({
+            nextRoot: path.join(
+              __dirname,
+              '__fixtures__',
+              'with-custom-error',
+              dataFetchingMethod
+            ),
+            route: '/random',
+          });
+
+          render();
+          expect(
+            screen.getByText(
+              '[CustomError] It looks like we have some problems. Status: 404'
+            )
+          ).toBeInTheDocument();
+        });
+      }
+    );
+  });
+});

--- a/src/__tests__/page-data-fetching/__fixtures__/pages/ssr/special-return.js
+++ b/src/__tests__/page-data-fetching/__fixtures__/pages/ssr/special-return.js
@@ -7,6 +7,6 @@ export default function ssr_notFound() {
 export async function getServerSideProps(ctx) {
   await sleep(1);
   return {
-    notFound: true,
+    x: true,
   };
 }

--- a/src/__tests__/page-data-fetching/page-data-fetching-special-returns.test.tsx
+++ b/src/__tests__/page-data-fetching/page-data-fetching-special-returns.test.tsx
@@ -1,21 +1,22 @@
 import type { CustomError } from '../../commonTypes';
 import { getPage } from '../../index';
-import * as NotFoundPage from './__fixtures__/pages/ssr/not-found';
+import * as SpecialReturnPage from './__fixtures__/pages/ssr/special-return';
 import path from 'path';
+import { InternalError } from '../../_error/error';
 
 describe('Data fetching with special return types', () => {
   describe('page with notFound', () => {
-    it('throws "missing prop field" error when not-found object is returned', async () => {
-      const returnObject = await NotFoundPage.getServerSideProps();
-      const expectedError: CustomError = new Error(
-        `[next-page-tester] Page's fetching method returned an object with unsupported fields. Supported fields are: \"[props, redirect]\". Returned value is available in error.payload.`
+    it('throws "missing prop field" error when "x" object is returned', async () => {
+      const returnObject = await SpecialReturnPage.getServerSideProps();
+      const expectedError: CustomError = new InternalError(
+        `Page's fetching method returned an object with unsupported fields. Supported fields are: \"[props, redirect, notFound]\". Returned value is available in error.payload.`
       );
       expectedError.payload = returnObject;
 
       await expect(
         getPage({
           nextRoot: path.join(__dirname, '__fixtures__'),
-          route: '/ssr/not-found',
+          route: '/ssr/special-return',
         })
       ).rejects.toThrow(expectedError);
     });

--- a/src/__tests__/page-extensions/page-extensions.test.tsx
+++ b/src/__tests__/page-extensions/page-extensions.test.tsx
@@ -16,15 +16,16 @@ describe('page file extensions', () => {
     });
 
     describe('unknown extension', () => {
-      it('throws "page not found" error', async () => {
-        await expect(
-          getPage({
-            nextRoot,
-            route: '/invalid',
-          })
-        ).rejects.toThrow(
-          '[next-page-tester] No matching page found for given route'
-        );
+      it('throws "page not found" error page', async () => {
+        const { render } = await getPage({
+          nextRoot,
+          route: '/invalid',
+        });
+        render();
+        expect(screen.getByText('404')).toBeInTheDocument();
+        expect(
+          screen.getByText('This page could not be found', { exact: false })
+        ).toBeInTheDocument();
       });
     });
   });
@@ -42,15 +43,17 @@ describe('page file extensions', () => {
       });
     });
     describe('not allowed extensions', () => {
-      it('throws "page not found" error', async () => {
-        await expect(
-          getPage({
-            nextRoot,
-            route: '/js',
-          })
-        ).rejects.toThrow(
-          '[next-page-tester] No matching page found for given route'
-        );
+      it('throws "page not found" error page', async () => {
+        const { render } = await getPage({
+          nextRoot,
+          route: '/js',
+        });
+        render();
+
+        expect(screen.getByText('404')).toBeInTheDocument();
+        expect(
+          screen.getByText('This page could not be found', { exact: false })
+        ).toBeInTheDocument();
       });
     });
   });

--- a/src/__tests__/routing/routing-dynamic-routes.test.tsx
+++ b/src/__tests__/routing/routing-dynamic-routes.test.tsx
@@ -5,6 +5,7 @@ import BlogPage from './__fixtures__/pages/blog/[id]';
 import BlogPage99 from './__fixtures__/pages/blog/99';
 import CatchAllPage from './__fixtures__/pages/catch-all/[id]/[...slug]';
 import OptionalCatchAllPage from './__fixtures__/pages/optional-catch-all/[id]/[[...slug]]';
+import { screen } from '@testing-library/react';
 
 const nextRoot = __dirname + '/__fixtures__';
 
@@ -79,15 +80,16 @@ describe('Dynamic routes', () => {
       expectDOMElementsToMatch(actual, expected);
     });
 
-    it('throws "page not found" error when no optional params are provided', async () => {
-      await expect(
-        getPage({
-          nextRoot,
-          route: '/catch-all/5',
-        })
-      ).rejects.toThrow(
-        '[next-page-tester] No matching page found for given route'
-      );
+    it('throws "page not found" error page when no optional params are provided', async () => {
+      const { render } = await getPage({
+        nextRoot,
+        route: '/catch-all/5',
+      });
+      render();
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found', { exact: false })
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/routing/routing-static-routes.test.tsx
+++ b/src/__tests__/routing/routing-static-routes.test.tsx
@@ -3,6 +3,7 @@ import { getPage } from '../../';
 import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
 import IndexPage from './__fixtures__/pages/index';
 import BlogIndexPage from './__fixtures__/pages/blog/index';
+import { screen } from '@testing-library/react';
 
 const nextRoot = __dirname + '/__fixtures__';
 
@@ -17,15 +18,17 @@ describe('Static routes', () => {
   });
 
   describe('route not matching any page', () => {
-    it('throws "page not found" error', async () => {
-      await expect(
-        getPage({
-          nextRoot,
-          route: '/blog/5/doesntexists',
-        })
-      ).rejects.toThrow(
-        '[next-page-tester] No matching page found for given route'
-      );
+    it('throws "page not found" error page', async () => {
+      const { render } = await getPage({
+        nextRoot,
+        route: '/blog/5/doesntexists',
+      });
+      render();
+
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found', { exact: false })
+      ).toBeInTheDocument();
     });
   });
 
@@ -39,10 +42,13 @@ describe('Static routes', () => {
   });
 
   describe('route === "_document"', () => {
-    it('throws "page not found" error', async () => {
-      await expect(getPage({ nextRoot, route: '/_document' })).rejects.toThrow(
-        '[next-page-tester] No matching page found for given route'
-      );
+    it('throws "page not found" error page', async () => {
+      const { render } = await getPage({ nextRoot, route: '/_document' });
+      render();
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found', { exact: false })
+      ).toBeInTheDocument();
     });
   });
 
@@ -64,14 +70,15 @@ describe('Static routes', () => {
 
   describe('route matching /api pages', () => {
     it('throws "page not found" error', async () => {
-      await expect(
-        getPage({
-          nextRoot,
-          route: '/api',
-        })
-      ).rejects.toThrow(
-        '[next-page-tester] No matching page found for given route'
-      );
+      const { render } = await getPage({
+        nextRoot,
+        route: '/api',
+      });
+      render();
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found', { exact: false })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/use-app/use-app.test.tsx
+++ b/src/__tests__/use-app/use-app.test.tsx
@@ -15,6 +15,7 @@ import CustomAppWithNextAppGIP_GIP from './__fixtures__/custom-app-with-next-app
 import SpecialExtensionCustomApp from './__fixtures__/special-extension/pages/_app';
 import SpecialExtensionPage from './__fixtures__/special-extension/pages/page';
 import MissingCustomAppPage from './__fixtures__/missing-custom-app/pages/page';
+import { screen } from '@testing-library/react';
 
 describe('_app support', () => {
   describe('_app with getInitialProps', () => {
@@ -149,15 +150,16 @@ describe('_app support', () => {
   });
 
   describe('route matching "_app" page', () => {
-    it('throws "page not found" error', async () => {
-      await expect(
-        getPage({
-          nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
-          route: '/_app',
-        })
-      ).rejects.toThrow(
-        '[next-page-tester] No matching page found for given route'
-      );
+    it('throws "page not found" error page', async () => {
+      const { render } = await getPage({
+        nextRoot: __dirname + '/__fixtures__/custom-app-with-gip',
+        route: '/_app',
+      });
+      render();
+      expect(screen.getByText('404')).toBeInTheDocument();
+      expect(
+        screen.getByText('This page could not be found', { exact: false })
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -8,6 +8,17 @@ import { renderToString } from 'react-dom/server';
 import { HeadManagerContext } from 'next/dist/next-server/lib/head-manager-context';
 import type { DocumentProps } from 'next/document';
 
+export const wrapWithDocument = (pageElement: JSX.Element) => {
+  return (
+    <html>
+      <head></head>
+      <body>
+        <div id="__next">{pageElement}</div>
+      </body>
+    </html>
+  );
+};
+
 export default async function renderDocument({
   pageElement,
   options,
@@ -23,14 +34,7 @@ export default async function renderDocument({
 
   // Return an empty dummy document if useDocument is not enabled
   if (!useDocument) {
-    return (
-      <html>
-        <head></head>
-        <body>
-          <div id="__next">{pageElement}</div>
-        </body>
-      </html>
-    );
+    return wrapWithDocument(pageElement);
   }
 
   const customDocumentFile = getDocumentFile({ options });

--- a/src/_error/error.ts
+++ b/src/_error/error.ts
@@ -1,0 +1,23 @@
+export class InternalError extends Error {
+  public static NAME = 'InternalError';
+
+  constructor(message: string) {
+    super(`[next-page-tester] ${message}`);
+    this.name = InternalError.NAME;
+  }
+}
+
+export class HttpError extends Error {
+  public readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+export class NotFoundError extends HttpError {
+  constructor(message: string = 'Not Found') {
+    super(message, 404);
+  }
+}

--- a/src/_error/fetchErrorData.ts
+++ b/src/_error/fetchErrorData.ts
@@ -1,0 +1,35 @@
+import { Fragment } from 'react';
+import { executeAsIfOnServer } from '../server';
+import DefaultErrorPage, { ErrorProps } from 'next/error';
+import type { ServerResponse } from 'http';
+import { HttpError } from './Error';
+import { ParsedUrlQuery } from 'querystring';
+
+export default async function fetchErrorData({
+  ErrorPage,
+  err,
+  res,
+  pathname,
+  query,
+}: {
+  ErrorPage: typeof DefaultErrorPage;
+  pathname: string;
+  query: ParsedUrlQuery;
+  res: ServerResponse;
+  err: HttpError;
+}): Promise<ErrorProps> {
+  let getErrorPageInitialProps = ErrorPage.getInitialProps;
+  if (!getErrorPageInitialProps) {
+    getErrorPageInitialProps = DefaultErrorPage.getInitialProps;
+  }
+
+  return executeAsIfOnServer(() =>
+    getErrorPageInitialProps({
+      res,
+      err,
+      pathname,
+      AppTree: Fragment,
+      query,
+    })
+  );
+}

--- a/src/_error/getCustomErrorFile.ts
+++ b/src/_error/getCustomErrorFile.ts
@@ -1,0 +1,14 @@
+import type { ExtendedOptions, NextAppFile } from '../commonTypes';
+import { loadPageIfExists } from '../loadPage';
+import { ERROR_PATH } from '../constants';
+
+export default function getCustomErrorFile({
+  options,
+}: {
+  options: ExtendedOptions;
+}) {
+  return loadPageIfExists<NextAppFile>({
+    pagePath: ERROR_PATH,
+    options,
+  });
+}

--- a/src/_error/index.ts
+++ b/src/_error/index.ts
@@ -1,0 +1,1 @@
+export { default as renderErrorPage } from './render';

--- a/src/_error/render.tsx
+++ b/src/_error/render.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import DefaultErrorPage from 'next/error';
+import getCustomErrorFile from './getCustomErrorFile';
+import fetchErrorData from './fetchErrorData';
+import { HttpError } from './Error';
+
+import type { ServerResponse } from 'http';
+
+import type { ExtendedOptions } from '../commonTypes';
+import { parseRouteData } from '../utils';
+import { wrapWithDocument } from '../_document/render';
+
+export default async function renderErrorPage({
+  options,
+  err,
+  res,
+}: {
+  options: ExtendedOptions;
+  err: HttpError;
+  res: ServerResponse;
+}) {
+  const customErrorFile = getCustomErrorFile({ options });
+  let ServerErrorPage = DefaultErrorPage;
+  let ClientErrorPage = DefaultErrorPage;
+  if (customErrorFile) {
+    ServerErrorPage = (customErrorFile.server
+      .default as unknown) as typeof DefaultErrorPage;
+    ClientErrorPage = (customErrorFile.client
+      .default as unknown) as typeof DefaultErrorPage;
+  }
+
+  const { pathname, query } = parseRouteData(options.route);
+
+  const initialProps = await fetchErrorData({
+    ErrorPage: ServerErrorPage,
+    pathname,
+    query,
+    err,
+    res,
+  });
+
+  return {
+    clientPageElement: <ClientErrorPage {...initialProps} />,
+    serverPageElement: wrapWithDocument(<ServerErrorPage {...initialProps} />),
+  };
+}

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -65,6 +65,7 @@ export type PageProps = {
 export type PageData<P extends PageProps = PageProps> = {
   props?: P;
   redirect?: Redirect;
+  notFound?: true;
 };
 
 export type NextPageFile = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const APP_PATH = '/_app' as const;
 export const DOCUMENT_PATH = '/_document' as const;
+export const ERROR_PATH = '/_error' as const;

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -17,6 +17,7 @@ import type {
 } from '../commonTypes';
 import type { CustomError } from '../commonTypes';
 import { executeAsIfOnServer } from '../server';
+import { InternalError } from '../_error/error';
 
 function ensureNoMultipleDataFetchingMethods({
   page,
@@ -34,9 +35,7 @@ function ensureNoMultipleDataFetchingMethods({
     methodsCounter++;
   }
   if (methodsCounter > 1) {
-    throw new Error(
-      '[next-page-tester] Only one data fetching method is allowed'
-    );
+    throw new InternalError('Only one data fetching method is allowed');
   }
 }
 
@@ -46,17 +45,17 @@ function ensurePageDataHasProps({
 }: {
   pageData: { [key: string]: any };
 }) {
-  const allowedKeys = ['props', 'redirect'];
+  const allowedKeys = ['props', 'redirect', 'notFound'];
   for (const key of allowedKeys) {
     if (key in pageData) {
       return;
     }
   }
 
-  const errorMessage = `[next-page-tester] Page's fetching method returned an object with unsupported fields. Supported fields are: "[${allowedKeys.join(
+  const errorMessage = `Page's fetching method returned an object with unsupported fields. Supported fields are: "[${allowedKeys.join(
     ', '
   )}]". Returned value is available in error.payload.`;
-  const error: CustomError = new Error(errorMessage);
+  const error: CustomError = new InternalError(errorMessage);
   error.payload = pageData;
   throw error;
 }

--- a/src/makePageElement.ts
+++ b/src/makePageElement.ts
@@ -2,6 +2,7 @@ import getPageObject from './getPageObject';
 import { fetchRouteData } from './fetchData';
 import { renderApp } from './_app';
 import type { ExtendedOptions, Page } from './commonTypes';
+import { NotFoundError } from './_error/error';
 
 /*
  * Return an instance of the page element corresponding
@@ -20,6 +21,10 @@ export default async function makePageElement({
     pageObject,
     options,
   });
+
+  if (pageData.notFound) {
+    throw new NotFoundError();
+  }
 
   if (pageData.redirect) {
     return makePageElement({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,12 @@ export function parseQueryString({
   return querystring.parse(qs);
 }
 
+export function parseRouteData(route: string) {
+  const { pathname, search } = parseRoute({ route });
+  const query = parseQueryString({ queryString: search });
+  return { query, pathname };
+}
+
 export function stringifyQueryString({
   object,
   leadingQuestionMark,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature:
- Implement ErrorPage rendering
- Add support for custom `_error` page

## What is the current behaviour?

Error thrown in user code are not catched and propagated. This doesn't reflect what the output would be in a real situtation for a user and makes it impossible to test "bad scenarios".

## What is the new behaviour?

Error page is rendered

## Does this PR introduce a breaking change?

Mostly likely no. Unless someone is catching exceptions in their tests.

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
