### PR TITLE
feature: support next/config runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The mounted application is **interactive** and can be tested with any DOM testin
 - wrapping page with custom `_app` and `_document` components
 - emulating **client side navigation** via `Link`, `router.push`, `router.replace`
 - handling pages' `redirect` returns
-- supporting `next/router`, `next/head`, `next/link`
+- supporting [`next/router`][next-docs-router], [`next/head`][next-docs-head], [`next/link`][next-docs-link], [`next/config`][next-docs-runtime-config]
 
 ## API
 
@@ -221,8 +221,11 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 [next-docs-routing]: https://nextjs.org/docs/routing/introduction
 [next-docs-data-fetching]: https://nextjs.org/docs/basic-features/data-fetching
 [next-docs-router]: https://nextjs.org/docs/api-reference/next/router
+[next-docs-link]: https://nextjs.org/docs/api-reference/next/link
+[next-docs-runtime-config]: https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration
+[next-docs-head]: https://nextjs.org/docs/api-reference/next/head
 [next-docs-custom-app]: https://nextjs.org/docs/advanced-features/custom-app
 [next-docs-custom-document]: https://nextjs.org/docs/advanced-features/custom-document
 [next-gh-strict-bug]: https://github.com/vercel/next.js/issues/16219
-[error-log-mock]: src/__tests__/use-document/use-document.test.tsx#L8
+[error-log-mock]: src/**tests**/use-document/use-document.test.tsx#L8
 [examples-folder]: examples

--- a/src/__tests__/next-config/__fixtures__/next.config.js
+++ b/src/__tests__/next-config/__fixtures__/next.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  serverRuntimeConfig: {
+    value: 'true',
+  },
+  publicRuntimeConfig: {
+    value: 'true',
+  },
+};

--- a/src/__tests__/next-config/__fixtures__/pages/page.tsx
+++ b/src/__tests__/next-config/__fixtures__/pages/page.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import getConfig from 'next/config';
+import { PropsPrinter } from '../../../__utils__';
+const config = getConfig();
+
+export default function RuntimeConfigPage({
+  configMock,
+}: {
+  configMock: { [key: string]: any };
+}) {
+  return (
+    <PropsPrinter
+      props={configMock || config}
+      suppressHydrationWarning={true}
+    />
+  );
+}

--- a/src/__tests__/next-config/next-config.test.tsx
+++ b/src/__tests__/next-config/next-config.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { getPage } from '../../index';
+import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
+import Page from './__fixtures__/pages/page';
+
+describe('Runtime Configuration with next/config', () => {
+  describe('server runtime', () => {
+    it('serverRuntimeConfig and publicRuntimeConfig available', async () => {
+      const { serverRender } = await getPage({
+        nextRoot: __dirname + '/__fixtures__',
+        route: '/page',
+      });
+      const { nextRoot: actual } = serverRender();
+      const { container: expected } = renderWithinNextRoot(
+        <Page
+          configMock={{
+            serverRuntimeConfig: {
+              value: 'true',
+            },
+            publicRuntimeConfig: {
+              value: 'true',
+            },
+          }}
+        />
+      );
+      expectDOMElementsToMatch(actual, expected);
+    });
+  });
+
+  describe('public runtime', () => {
+    it('only publicRuntimeConfig available', async () => {
+      const { render } = await getPage({
+        nextRoot: __dirname + '/__fixtures__',
+        route: '/page',
+      });
+      const { nextRoot: actual } = render();
+      const { container: expected } = renderWithinNextRoot(
+        <Page
+          configMock={{
+            publicRuntimeConfig: {
+              value: 'true',
+            },
+          }}
+        />
+      );
+      expectDOMElementsToMatch(actual, expected);
+    });
+  });
+});

--- a/src/__tests__/next-config/next-config.test.tsx
+++ b/src/__tests__/next-config/next-config.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { getPage } from '../../index';
 import { expectDOMElementsToMatch, renderWithinNextRoot } from '../__utils__';
-import Page from './__fixtures__/pages/page';
 
 describe('Runtime Configuration with next/config', () => {
   describe('server runtime', () => {
@@ -10,6 +9,12 @@ describe('Runtime Configuration with next/config', () => {
         nextRoot: __dirname + '/__fixtures__',
         route: '/page',
       });
+      /*
+       * @NOTE: we need to import Page component after next-page-tester runs because
+       * Page component stores next/config value at module load time when runtime config
+       * value is still undefined (This would also happen in an actual Next.js application)
+       */
+      const Page = require('./__fixtures__/pages/page').default;
       const { nextRoot: actual } = serverRender();
       const { container: expected } = renderWithinNextRoot(
         <Page
@@ -33,10 +38,12 @@ describe('Runtime Configuration with next/config', () => {
         nextRoot: __dirname + '/__fixtures__',
         route: '/page',
       });
+      const Page = require('./__fixtures__/pages/page').default;
       const { nextRoot: actual } = render();
       const { container: expected } = renderWithinNextRoot(
         <Page
           configMock={{
+            serverRuntimeConfig: {},
             publicRuntimeConfig: {
               value: 'true',
             },

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -7,6 +7,8 @@ import { renderDocument } from './_document';
 import { renderApp } from './_app';
 import initHeadManager from 'next/dist/client/head-manager';
 import { HeadManagerContext } from 'next/dist/next-server/lib/head-manager-context';
+import { loadNextConfig } from './nextConfig';
+import setNextRuntimeConfig from './setNextRuntimeConfig';
 import {
   defaultNextRoot,
   findPagesDirectory,
@@ -52,11 +54,13 @@ export default async function getPage({
     useDocument,
   };
   validateOptions(optionsWithDefaults);
+  loadNextConfig({ nextRoot });
+  setNextRuntimeConfig({ runtimeEnv: 'client' });
 
   const options: ExtendedOptions = {
     ...optionsWithDefaults,
     pagesDirectory: findPagesDirectory({ nextRoot }),
-    pageExtensions: getPageExtensions({ nextRoot }),
+    pageExtensions: getPageExtensions(),
     env: 'server',
   };
   // @TODO: Consider printing extended options value behind a debug flag

--- a/src/nextConfig.ts
+++ b/src/nextConfig.ts
@@ -1,0 +1,24 @@
+import loadConfig, { NextConfig } from 'next/dist/next-server/server/config';
+import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
+
+let nextConfig: NextConfig;
+export function loadNextConfig({ nextRoot }: { nextRoot: string }) {
+  nextConfig = loadConfig(PHASE_DEVELOPMENT_SERVER, nextRoot);
+}
+
+/*
+ * Retrieve Next.js config using Next.js internals
+ * https://github.com/vercel/next.js/blob/v10.0.1/test/isolated/config.test.js#L12
+ *
+ * Default config:
+ * https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config.ts
+ */
+export function getNextConfig(): NextConfig {
+  /* istanbul ignore if */
+  if (!nextConfig) {
+    throw new Error(
+      '[next-page-tester] getNextConfig called before loadNextConfig'
+    );
+  }
+  return nextConfig;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import setNextRuntimeConfig from './setNextRuntimeConfig';
 import { executeWithFreshModules } from './utils';
 
 export const requireAsIfOnServer = <FileType>(path: string): FileType => {
@@ -14,12 +15,14 @@ export const executeAsIfOnServer = async <T>(f: () => T) => {
   delete global.window;
   // @ts-ignore
   delete global.document;
+  setNextRuntimeConfig({ runtimeEnv: 'server' });
 
   try {
     return await f();
   } finally {
     global.window = tmpWindow;
     global.document = tmpDocument;
+    setNextRuntimeConfig({ runtimeEnv: 'client' });
   }
 };
 
@@ -31,11 +34,13 @@ export const executeAsIfOnServerSync = <T>(f: () => T): T => {
   delete global.window;
   // @ts-ignore
   delete global.document;
+  setNextRuntimeConfig({ runtimeEnv: 'server' });
 
   try {
     return f();
   } finally {
     global.window = tmpWindow;
     global.document = tmpDocument;
+    setNextRuntimeConfig({ runtimeEnv: 'client' });
   }
 };

--- a/src/setNextRuntimeConfig.ts
+++ b/src/setNextRuntimeConfig.ts
@@ -1,4 +1,4 @@
-import * as envConfig from 'next/dist/next-server/lib/runtime-config';
+import { setConfig } from 'next/dist/next-server/lib/runtime-config';
 import { getNextConfig } from './nextConfig';
 
 export default function setNextRuntimeConfig({

--- a/src/setNextRuntimeConfig.ts
+++ b/src/setNextRuntimeConfig.ts
@@ -9,7 +9,7 @@ export default function setNextRuntimeConfig({
   const config = getNextConfig();
   const { serverRuntimeConfig, publicRuntimeConfig } = config;
 
-  envConfig.setConfig({
+  setConfig({
     serverRuntimeConfig: runtimeEnv === 'server' ? serverRuntimeConfig : {},
     publicRuntimeConfig,
   });

--- a/src/setNextRuntimeConfig.ts
+++ b/src/setNextRuntimeConfig.ts
@@ -1,0 +1,16 @@
+import * as envConfig from 'next/dist/next-server/lib/runtime-config';
+import { getNextConfig } from './nextConfig';
+
+export default function setNextRuntimeConfig({
+  runtimeEnv,
+}: {
+  runtimeEnv: 'server' | 'client';
+}): void {
+  const config = getNextConfig();
+  const { serverRuntimeConfig = {}, publicRuntimeConfig = {} } = config;
+
+  envConfig.setConfig({
+    serverRuntimeConfig: runtimeEnv === 'server' ? serverRuntimeConfig : {},
+    publicRuntimeConfig,
+  });
+}

--- a/src/setNextRuntimeConfig.ts
+++ b/src/setNextRuntimeConfig.ts
@@ -7,7 +7,7 @@ export default function setNextRuntimeConfig({
   runtimeEnv: 'server' | 'client';
 }): void {
   const config = getNextConfig();
-  const { serverRuntimeConfig = {}, publicRuntimeConfig = {} } = config;
+  const { serverRuntimeConfig, publicRuntimeConfig } = config;
 
   envConfig.setConfig({
     serverRuntimeConfig: runtimeEnv === 'server' ? serverRuntimeConfig : {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,9 @@ import { useRef, useEffect, useCallback } from 'react';
 import querystring from 'querystring';
 import findRoot from 'find-root';
 import { existsSync } from 'fs';
-import loadConfig from 'next/dist/next-server/server/config';
-import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
 import path from 'path';
 import stealthyRequire from 'stealthy-require';
+import { getNextConfig } from './nextConfig';
 
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
@@ -72,23 +71,8 @@ export function findPagesDirectory({ nextRoot }: { nextRoot: string }) {
   );
 }
 
-/*
- * Retrieve Next.js config using Next.js internals
- * https://github.com/vercel/next.js/blob/v10.0.1/test/isolated/config.test.js#L12
- *
- * Default config:
- * https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/config.ts
- */
-function getNextConfig({ pathToConfig }: { pathToConfig: string }) {
-  return loadConfig(PHASE_DEVELOPMENT_SERVER, pathToConfig);
-}
-
-export function getPageExtensions({
-  nextRoot,
-}: {
-  nextRoot: string;
-}): string[] {
-  const config = getNextConfig({ pathToConfig: nextRoot });
+export function getPageExtensions(): string[] {
+  const config = getNextConfig();
   return config.pageExtensions as string[];
 }
 
@@ -111,6 +95,7 @@ const nonIsolatedModules = [
   'next/router',
   'next/dist/next-server/lib/head-manager-context',
   'next/dist/next-server/lib/router-context',
+  'next/dist/next-server/lib/runtime-config',
 ];
 export function executeWithFreshModules<T>(f: () => T): T {
   /* istanbul ignore else */


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

`next/config` is not set and always returns `undefined`.

## What is the new behaviour?

Support [Next.js runtime configuration](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration) and set different `next/config` values based on `server` or `client` env. 

## Does this PR introduce a breaking change?

Yes.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [x] Docs have been added / updated
