### PR TITLE
chore: refactor v1

### DIFF
--- a/src/RouterProvider.tsx
+++ b/src/RouterProvider.tsx
@@ -1,39 +1,45 @@
 import React, { useState, useCallback, useRef } from 'react';
+
 import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import makeRouterMock, { PushHandler } from './makeRouterMock';
 import { useMountedState } from './utils';
-import type { ExtendedOptions, Page, PageObject } from './commonTypes';
+import {
+  ExtendedOptions,
+  Page,
+  RuntimeEnvironment,
+  RouteData,
+} from './commonTypes';
 
-export default function RouterProvider({
-  pageObject,
-  options,
-  children: initialChildren,
-  makePage,
-}: {
-  pageObject: PageObject;
-  options: ExtendedOptions;
+type Props = {
+  routerEnhancer: ExtendedOptions['router'];
+  routeData: RouteData;
   children: JSX.Element;
   makePage: (optionsOverride?: Partial<ExtendedOptions>) => Promise<Page>;
-}) {
+};
+
+export default function RouterProvider({
+  routerEnhancer,
+  routeData,
+  children: initialChildren,
+  makePage,
+}: Props) {
   const isMounted = useMountedState();
-  const previousRouteRef = useRef(pageObject.route);
+  const previousRouteRef = useRef(routeData.route);
 
   const pushHandler = useCallback(async (url: Parameters<PushHandler>[0]) => {
     const nextRoute = url.toString();
-    const nextOptions = { ...options, route: nextRoute };
-
     const previousRoute = previousRouteRef.current;
     const { pageElement, pageObject } = await makePage({
       route: nextRoute,
       previousRoute,
-      env: 'client',
+      env: RuntimeEnvironment.CLIENT,
     });
     previousRouteRef.current = nextRoute;
 
     const nextRouter = makeRouterMock({
-      options: nextOptions,
-      pageObject,
+      routeData: pageObject,
       pushHandler,
+      routerEnhancer,
     });
 
     // Avoid errors if page gets unmounted
@@ -49,8 +55,8 @@ export default function RouterProvider({
   const [{ children, router }, setState] = useState(() => ({
     children: initialChildren,
     router: makeRouterMock({
-      options,
-      pageObject,
+      routerEnhancer,
+      routeData,
       pushHandler,
     }),
   }));

--- a/src/_app/fetchAppData.ts
+++ b/src/_app/fetchAppData.ts
@@ -3,7 +3,11 @@ import type { AppContext, AppInitialProps } from 'next/app';
 import makeRouterMock from '../makeRouterMock';
 import { makeGetInitialPropsContext } from '../fetchData/makeContextObject';
 import { executeAsIfOnServer } from '../server';
-import type { PageObject, ExtendedOptions } from '../commonTypes';
+import {
+  PageObject,
+  ExtendedOptions,
+  RuntimeEnvironment,
+} from '../commonTypes';
 
 export default async function fetchAppData({
   pageObject,
@@ -19,24 +23,21 @@ export default async function fetchAppData({
   const { getInitialProps } = AppComponent;
   if (getInitialProps) {
     const { asPath, pathname, query, route, basePath } = makeRouterMock({
-      options,
-      pageObject,
+      routeData: pageObject,
+      routerEnhancer: options.router,
     });
 
     const ctx: AppContext = {
       // @NOTE AppTree is currently just a stub
       AppTree: Fragment,
       Component: pageObject.page.client.default,
-      ctx: makeGetInitialPropsContext({
-        pageObject,
-        options,
-      }),
+      ctx: makeGetInitialPropsContext({ pageObject, options }),
       // @ts-expect-error incomplete router object
       router: { asPath, pathname, query, route, basePath },
     };
 
     const appInitialProps =
-      env === 'server'
+      env === RuntimeEnvironment.SERVER
         ? await executeAsIfOnServer(() => getInitialProps(ctx))
         : await getInitialProps(ctx);
 

--- a/src/_app/getAppFile.ts
+++ b/src/_app/getAppFile.ts
@@ -7,15 +7,18 @@ import { APP_PATH } from '../constants';
 import DefaultApp from './DefaultApp';
 
 export function getAppFile({
-  options,
-}: {
-  options: ExtendedOptions;
-}): PageFile<NextAppFile> {
-  const { useApp } = options;
+  pageExtensions,
+  pagesDirectory,
+  useApp,
+}: Pick<
+  ExtendedOptions,
+  'pageExtensions' | 'pagesDirectory' | 'useApp'
+>): PageFile<NextAppFile> {
   if (useApp) {
     const customAppFile = loadPageIfExists<NextAppFile>({
       pagePath: APP_PATH,
-      options,
+      pageExtensions,
+      pagesDirectory,
     });
 
     if (customAppFile) {

--- a/src/_document/getDocumentFile.ts
+++ b/src/_document/getDocumentFile.ts
@@ -7,13 +7,16 @@ import { loadPageIfExists, loadFile } from '../loadPage';
 import { DOCUMENT_PATH } from '../constants';
 
 export default function getDocumentFile({
-  options,
-}: {
-  options: ExtendedOptions;
-}): PageFile<NextDocumentFile> {
+  pageExtensions,
+  pagesDirectory,
+}: Pick<
+  ExtendedOptions,
+  'pageExtensions' | 'pagesDirectory'
+>): PageFile<NextDocumentFile> {
   const customDocumentFile = loadPageIfExists<NextDocumentFile>({
-    options,
     pagePath: DOCUMENT_PATH,
+    pageExtensions,
+    pagesDirectory,
   });
 
   if (customDocumentFile) {

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -33,7 +33,7 @@ export default async function renderDocument({
     );
   }
 
-  const customDocumentFile = getDocumentFile({ options });
+  const customDocumentFile = getDocumentFile(options);
   const Document = customDocumentFile.server.default;
 
   const renderPage: RenderPage = () => {

--- a/src/_error/error.ts
+++ b/src/_error/error.ts
@@ -1,0 +1,5 @@
+export class InternalError extends Error {
+  constructor(message: string) {
+    super(`[next-page-tester] ${message}`);
+  }
+}

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -29,12 +29,17 @@ export type Options = {
 
 export type OptionsWithDefaults = Required<Options>;
 
+export enum RuntimeEnvironment {
+  SERVER = 'server',
+  CLIENT = 'client',
+}
+
 // Options object is extended with some extra derived props
 export type ExtendedOptions = OptionsWithDefaults & {
   pagesDirectory: string;
   pageExtensions: string[];
   previousRoute?: string;
-  env: 'server' | 'client';
+  env: RuntimeEnvironment;
 };
 
 /*
@@ -47,14 +52,17 @@ export type PageFile<FileType> = {
 
 export type PageParams = ParsedUrlQuery;
 
-export type PageObject = {
-  page: PageFile<NextPageFile>;
-  appFile: PageFile<NextAppFile>;
+export type RouteData = {
+  params: PageParams;
+  query: PageParams;
   route: string;
   pagePath: string;
-  params: PageParams;
+};
+
+export type PageObject = RouteData & {
+  page: PageFile<NextPageFile>;
+  appFile: PageFile<NextAppFile>;
   paramsNumber: number;
-  query: PageParams;
   resolvedUrl: string;
 };
 

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -9,14 +9,16 @@ import {
   makeGetServerSidePropsContext,
   makeStaticPropsContext,
 } from './makeContextObject';
-import type {
+import {
   ExtendedOptions,
   PageObject,
   PageData,
   NextPageFile,
+  RuntimeEnvironment,
 } from '../commonTypes';
 import type { CustomError } from '../commonTypes';
 import { executeAsIfOnServer } from '../server';
+import { InternalError } from '../_error/error';
 
 function ensureNoMultipleDataFetchingMethods({
   page,
@@ -34,9 +36,7 @@ function ensureNoMultipleDataFetchingMethods({
     methodsCounter++;
   }
   if (methodsCounter > 1) {
-    throw new Error(
-      '[next-page-tester] Only one data fetching method is allowed'
-    );
+    throw new InternalError('Only one data fetching method is allowed');
   }
 }
 
@@ -122,7 +122,7 @@ export default async function fetchPageData({
       pageObject,
     });
 
-    if (env === 'client') {
+    if (env === RuntimeEnvironment.CLIENT) {
       const initialProps = await getInitialProps(ctx);
       return { props: initialProps };
     } else {

--- a/src/getPagePaths.ts
+++ b/src/getPagePaths.ts
@@ -5,10 +5,11 @@ import type { ExtendedOptions } from './commonTypes';
 
 // Returns available page paths without file extension
 async function getPagePaths({
-  options: { pagesDirectory, pageExtensions },
-}: {
-  options: ExtendedOptions;
-}): Promise<string[]> {
+  pagesDirectory,
+  pageExtensions,
+}: Pick<ExtendedOptions, 'pageExtensions' | 'pagesDirectory'>): Promise<
+  string[]
+> {
   const files = await fastGlob([
     normalizePath(path.join(pagesDirectory, '**', '*')),
   ]);

--- a/src/loadPage.ts
+++ b/src/loadPage.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { existsSync } from 'fs';
 import { requireAsIfOnServer } from './server';
 import type { ExtendedOptions, PageFile } from './commonTypes';
+import { InternalError } from './_error/error';
 
 export function loadFile<FileType>({
   absolutePath,
@@ -14,14 +15,18 @@ export function loadFile<FileType>({
   };
 }
 
+type LoadPageOptions = Pick<
+  ExtendedOptions,
+  'pageExtensions' | 'pagesDirectory'
+> & {
+  pagePath: string;
+};
+
 export function loadPage<FileType>({
   pagePath,
-  options,
-}: {
-  pagePath: string;
-  options: ExtendedOptions;
-}): PageFile<FileType> {
-  const { pagesDirectory, pageExtensions } = options;
+  pageExtensions,
+  pagesDirectory,
+}: LoadPageOptions): PageFile<FileType> {
   // @NOTE Here we have to remove pagePath's leading "/"
   const absolutePath = path.resolve(pagesDirectory, pagePath.substring(1));
 
@@ -32,20 +37,16 @@ export function loadPage<FileType>({
     }
   }
 
-  throw new Error(
-    "[next-page-tester] Couldn't find required page file with matching extension"
+  throw new InternalError(
+    "Couldn't find required page file with matching extension"
   );
 }
 
-export function loadPageIfExists<FileType>({
-  pagePath,
-  options,
-}: {
-  pagePath: string;
-  options: ExtendedOptions;
-}): PageFile<FileType> | undefined {
+export function loadPageIfExists<FileType>(
+  options: LoadPageOptions
+): PageFile<FileType> | undefined {
   try {
-    return loadPage({ pagePath, options });
+    return loadPage(options);
   } catch (e) {
     return undefined;
   }

--- a/src/makePageElement.ts
+++ b/src/makePageElement.ts
@@ -12,9 +12,7 @@ export default async function makePageElement({
 }: {
   options: ExtendedOptions;
 }): Promise<Page> {
-  const pageObject = await getPageObject({
-    options,
-  });
+  const pageObject = await getPageObject(options);
 
   const pageData = await fetchRouteData({
     pageObject,

--- a/src/makeRenderMethods.ts
+++ b/src/makeRenderMethods.ts
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 import { executeAsIfOnServerSync } from './server';
+import { InternalError } from './_error/error';
 
 export function makeRenderMethods({
   serverPageElement,
@@ -41,7 +42,7 @@ export function makeRenderMethods({
     const nextRoot = document.getElementById('__next');
     /* istanbul ignore next */
     if (!nextRoot) {
-      throw new Error('[next-page-tester] Missing __next div');
+      throw new InternalError('Missing __next div');
     }
 
     return { nextRoot };

--- a/src/makeRouterMock.ts
+++ b/src/makeRouterMock.ts
@@ -1,6 +1,6 @@
 import type { NextRouter } from 'next/router';
 import { removeFileExtension, parseRoute } from './utils';
-import type { OptionsWithDefaults, PageObject } from './commonTypes';
+import type { OptionsWithDefaults, RouteData } from './commonTypes';
 
 type NextPushArgs = Parameters<NextRouter['push']>;
 export type PushHandler = (
@@ -45,12 +45,12 @@ function makeDefaultRouterMock({
 }
 
 export default function makeRouterMock({
-  options,
-  pageObject: { pagePath, params, route, query },
+  routerEnhancer,
+  routeData: { pagePath, params, route, query },
   pushHandler,
 }: {
-  options: OptionsWithDefaults;
-  pageObject: PageObject;
+  routerEnhancer: OptionsWithDefaults['router'];
+  routeData: RouteData;
   pushHandler?: PushHandler;
 }): NextRouter {
   const { pathname, search, hash } = parseRoute({ route });
@@ -63,5 +63,5 @@ export default function makeRouterMock({
     basePath: '',
   };
 
-  return options.router(router);
+  return routerEnhancer(router);
 }

--- a/src/nextConfig.ts
+++ b/src/nextConfig.ts
@@ -1,5 +1,6 @@
 import loadConfig, { NextConfig } from 'next/dist/next-server/server/config';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants';
+import { InternalError } from './_error/error';
 
 let nextConfig: NextConfig;
 export function loadNextConfig({ nextRoot }: { nextRoot: string }) {
@@ -16,9 +17,7 @@ export function loadNextConfig({ nextRoot }: { nextRoot: string }) {
 export function getNextConfig(): NextConfig {
   /* istanbul ignore if */
   if (!nextConfig) {
-    throw new Error(
-      '[next-page-tester] getNextConfig called before loadNextConfig'
-    );
+    throw new InternalError('getNextConfig called before loadNextConfig');
   }
   return nextConfig;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import { RuntimeEnvironment } from './commonTypes';
 import setNextRuntimeConfig from './setNextRuntimeConfig';
 import { executeWithFreshModules } from './utils';
 
@@ -15,14 +16,14 @@ export const executeAsIfOnServer = async <T>(f: () => T) => {
   delete global.window;
   // @ts-expect-error its okay
   delete global.document;
-  setNextRuntimeConfig({ runtimeEnv: 'server' });
+  setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.SERVER });
 
   try {
     return await f();
   } finally {
     global.window = tmpWindow;
     global.document = tmpDocument;
-    setNextRuntimeConfig({ runtimeEnv: 'client' });
+    setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.CLIENT });
   }
 };
 
@@ -34,13 +35,13 @@ export const executeAsIfOnServerSync = <T>(f: () => T): T => {
   delete global.window;
   // @ts-expect-error its okay
   delete global.document;
-  setNextRuntimeConfig({ runtimeEnv: 'server' });
+  setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.SERVER });
 
   try {
     return f();
   } finally {
     global.window = tmpWindow;
     global.document = tmpDocument;
-    setNextRuntimeConfig({ runtimeEnv: 'client' });
+    setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.CLIENT });
   }
 };

--- a/src/setNextRuntimeConfig.ts
+++ b/src/setNextRuntimeConfig.ts
@@ -1,10 +1,11 @@
 import { setConfig } from 'next/dist/next-server/lib/runtime-config';
+import { RuntimeEnvironment } from './commonTypes';
 import { getNextConfig } from './nextConfig';
 
 export default function setNextRuntimeConfig({
   runtimeEnv,
 }: {
-  runtimeEnv: 'server' | 'client';
+  runtimeEnv: RuntimeEnvironment;
 }): void {
   const config = getNextConfig();
   const { serverRuntimeConfig, publicRuntimeConfig } = config;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import { existsSync } from 'fs';
 import path from 'path';
 import stealthyRequire from 'stealthy-require';
 import { getNextConfig } from './nextConfig';
+import { InternalError } from './_error/error';
 
 export function parseRoute({ route }: { route: string }) {
   const urlObject = new URL(`http://test.com${route}`);
@@ -66,9 +67,7 @@ export function findPagesDirectory({ nextRoot }: { nextRoot: string }) {
     }
   }
 
-  throw new Error(
-    `[next-page-tester] Cannot find "pages" directory under: ${nextRoot}`
-  );
+  throw new InternalError(`Cannot find "pages" directory under: ${nextRoot}`);
 }
 
 export function getPageExtensions(): string[] {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor.

## What is the current behaviour?

Implementing some of new features like [custom error page](https://nextjs.org/docs/advanced-features/custom-error-page) and [customizing render page](https://nextjs.org/docs/advanced-features/custom-document#customizing-renderpage) require some refactoring.

Currently the main problem I'm facing is passing around excessive objects (prop drilling)  e.g. `"options" ` and `"pageObject"` that are actually not needed by the functions (only some fields are needed). When handling errors, page might throw early in the process (e.g. in data fetching methods) meaning we wont have all the data needed to construct those complex data.

We should aim to keep function parameters and return types to minimum (only what the functions need to receive/return). This will make them more reusable in different contexts where not all the data is available to construct whole objects.

## What is the new behaviour?

Small refactor that tries to fix some of the problems mentioned above. There are still many places where we are passing much more than actually needed, but they can be fixed as we go.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
