### PR TITLE
fix: client side object navigation

### DIFF
--- a/src/RouterProvider.tsx
+++ b/src/RouterProvider.tsx
@@ -3,6 +3,7 @@ import { RouterContext } from 'next/dist/next-server/lib/router-context';
 import makeRouterMock, { PushHandler } from './makeRouterMock';
 import { useMountedState } from './utils';
 import type { ExtendedOptions, Page, PageObject } from './commonTypes';
+import { formatUrl } from 'next/dist/next-server/lib/router/utils/format-url';
 
 export default function RouterProvider({
   pageObject,
@@ -19,7 +20,7 @@ export default function RouterProvider({
   const previousRouteRef = useRef(pageObject.route);
 
   const pushHandler = useCallback(async (url: Parameters<PushHandler>[0]) => {
-    const nextRoute = url.toString();
+    const nextRoute = typeof url === 'string' ? url : formatUrl(url);
     const nextOptions = { ...options, route: nextRoute };
 
     const previousRoute = previousRouteRef.current;

--- a/src/__tests__/client-navigation/__fixtures__/PageA.tsx
+++ b/src/__tests__/client-navigation/__fixtures__/PageA.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Link from 'next/link';
+import { UrlObject } from 'url';
+import { useRouter } from 'next/router';
+
+type Props = {
+  href: string;
+  hrefObject: UrlObject;
+};
+
+export const PageA = ({ href, hrefObject }: Props) => {
+  const { replace } = useRouter();
+
+  const goToPageBstring = () => {
+    replace(href);
+  };
+
+  const goToPageBObject = () => {
+    replace(hrefObject);
+  };
+
+  return (
+    <div>
+      <h2>This is page A</h2>
+
+      <Link href={href}>
+        <a>Go to B with Link (with string)</a>
+      </Link>
+      <Link href={hrefObject}>
+        <a>Go to B with Link (with object)</a>
+      </Link>
+
+      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
+      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
+    </div>
+  );
+};

--- a/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
+++ b/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { basename } from 'path';
+import { PageA } from '../PageA';
 
 const expectedRoute = `/${basename(__filename, '.tsx')}`;
 
 export default function ClientSideNavigationA() {
-  const { replace, route } = useRouter();
+  const { route } = useRouter();
 
   // Ensure client side navigation updates router & page in same tick
   if (route !== expectedRoute) {
@@ -15,30 +15,10 @@ export default function ClientSideNavigationA() {
     );
   }
 
-  const href = '/b?foo=bar';
-  const hrefObject = { pathname: '/b', query: { foo: 'bar' } };
-
-  const goToPageBstring = () => {
-    replace(href);
-  };
-
-  const goToPageBObject = () => {
-    replace(hrefObject);
-  };
-
   return (
-    <div>
-      <h2>This is page A</h2>
-
-      <Link href={href}>
-        <a>Go to B with Link (with string)</a>
-      </Link>
-      <Link href={hrefObject}>
-        <a>Go to B with Link (with object)</a>
-      </Link>
-
-      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
-      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
-    </div>
+    <PageA
+      href="/b?foo=bar"
+      hrefObject={{ pathname: '/b', query: { foo: 'bar' } }}
+    />
   );
 }

--- a/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
+++ b/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
@@ -15,17 +15,24 @@ export default function ClientSideNavigationA() {
     );
   }
 
-  const goToPageB = () => {
-    replace('/b');
+  const href = '/b?foo=bar';
+
+  const goToPageBstring = () => {
+    replace(href);
+  };
+
+  const goToPageBObject = () => {
+    replace({ pathname: '/b', query: { foo: 'bar' } });
   };
 
   return (
     <div>
       <h2>This is page A</h2>
-      <Link href="/b">
+      <Link href={href}>
         <a>Go to B with Link</a>
       </Link>
-      <a onClick={goToPageB}>Go to B programmatically</a>
+      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
+      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
     </div>
   );
 }

--- a/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
+++ b/src/__tests__/client-navigation/__fixtures__/pages/a.tsx
@@ -16,21 +16,27 @@ export default function ClientSideNavigationA() {
   }
 
   const href = '/b?foo=bar';
+  const hrefObject = { pathname: '/b', query: { foo: 'bar' } };
 
   const goToPageBstring = () => {
     replace(href);
   };
 
   const goToPageBObject = () => {
-    replace({ pathname: '/b', query: { foo: 'bar' } });
+    replace(hrefObject);
   };
 
   return (
     <div>
       <h2>This is page A</h2>
+
       <Link href={href}>
-        <a>Go to B with Link</a>
+        <a>Go to B with Link (with string)</a>
       </Link>
+      <Link href={hrefObject}>
+        <a>Go to B with Link (with object)</a>
+      </Link>
+
       <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
       <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
     </div>

--- a/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
@@ -3,10 +3,16 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 export default function ClientSideNavigationAGIP(props) {
-  const href = '/gip/b';
-  const router = useRouter();
-  const goToPageB = () => {
-    router.replace(href);
+  const href = '/gip/b?foo=bar';
+
+  const { replace } = useRouter();
+
+  const goToPageBstring = () => {
+    replace(href);
+  };
+
+  const goToPageBobject = () => {
+    replace({ pathname: '/gip/b', query: { foo: 'bar' } });
   };
 
   return (
@@ -15,7 +21,8 @@ export default function ClientSideNavigationAGIP(props) {
       <Link href={href}>
         <a>Go to B with Link</a>
       </Link>
-      <a onClick={goToPageB}>Go to B programmatically</a>
+      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
+      <a onClick={goToPageBobject}>Go to B programmatically (with object)</a>
 
       <span>{JSON.stringify(props)}</span>
     </div>

--- a/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 export default function ClientSideNavigationAGIP(props) {
+  const hrefObject = { pathname: '/gip/b', query: { foo: 'bar' } };
   const href = '/gip/b?foo=bar';
 
   const { replace } = useRouter();
@@ -12,15 +13,20 @@ export default function ClientSideNavigationAGIP(props) {
   };
 
   const goToPageBobject = () => {
-    replace({ pathname: '/gip/b', query: { foo: 'bar' } });
+    replace(hrefObject);
   };
 
   return (
     <div>
       <h2>This is page A</h2>
+
       <Link href={href}>
-        <a>Go to B with Link</a>
+        <a>Go to B with Link (with string)</a>
       </Link>
+      <Link href={hrefObject}>
+        <a>Go to B with Link (with object)</a>
+      </Link>
+
       <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
       <a onClick={goToPageBobject}>Go to B programmatically (with object)</a>
 

--- a/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/gip/a.js
@@ -1,37 +1,16 @@
 import React from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
+import { PageA } from '../../PageA';
 
 export default function ClientSideNavigationAGIP(props) {
-  const hrefObject = { pathname: '/gip/b', query: { foo: 'bar' } };
-  const href = '/gip/b?foo=bar';
-
-  const { replace } = useRouter();
-
-  const goToPageBstring = () => {
-    replace(href);
-  };
-
-  const goToPageBobject = () => {
-    replace(hrefObject);
-  };
-
   return (
-    <div>
-      <h2>This is page A</h2>
-
-      <Link href={href}>
-        <a>Go to B with Link (with string)</a>
-      </Link>
-      <Link href={hrefObject}>
-        <a>Go to B with Link (with object)</a>
-      </Link>
-
-      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
-      <a onClick={goToPageBobject}>Go to B programmatically (with object)</a>
+    <>
+      <PageA
+        href="/gip/b?foo=bar"
+        hrefObject={{ pathname: '/gip/b', query: { foo: 'bar' } }}
+      />
 
       <span>{JSON.stringify(props)}</span>
-    </div>
+    </>
   );
 }
 

--- a/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
@@ -1,37 +1,15 @@
 import React from 'react';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
+import { PageA } from '../../PageA';
 
 export default function ClientSideNavigationAGIP(props) {
-  const hrefObject = { pathname: '/ssr/b', query: { foo: 'bar' } };
-  const href = '/ssr/b?foo=bar';
-
-  const { replace } = useRouter();
-
-  const goToPageBstring = () => {
-    replace(href);
-  };
-
-  const goToPageBObject = () => {
-    replace(hrefObject);
-  };
-
   return (
-    <div>
-      <h2>This is page A</h2>
-
-      <Link href={href}>
-        <a>Go to B with Link (with string)</a>
-      </Link>
-      <Link href={hrefObject}>
-        <a>Go to B with Link (with object)</a>
-      </Link>
-
-      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
-      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
-
+    <>
+      <PageA
+        href="/ssr/b?foo=bar"
+        hrefObject={{ pathname: '/ssr/b', query: { foo: 'bar' } }}
+      />
       <span>{JSON.stringify(props)}</span>
-    </div>
+    </>
   );
 }
 

--- a/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
@@ -3,11 +3,16 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 export default function ClientSideNavigationAGIP(props) {
-  const href = '/ssr/b';
+  const href = '/ssr/b?foo=bar';
 
-  const router = useRouter();
-  const goToPageB = () => {
-    router.replace(href);
+  const { replace } = useRouter();
+
+  const goToPageBstring = () => {
+    replace(href);
+  };
+
+  const goToPageBObject = () => {
+    replace({ pathname: '/ssr/b', query: { foo: 'bar' } });
   };
 
   return (
@@ -16,7 +21,8 @@ export default function ClientSideNavigationAGIP(props) {
       <Link href={href}>
         <a>Go to B with Link</a>
       </Link>
-      <a onClick={goToPageB}>Go to B programmatically</a>
+      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
+      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
 
       <span>{JSON.stringify(props)}</span>
     </div>

--- a/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
+++ b/src/__tests__/client-navigation/__fixtures__/pages/ssr/a.js
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 
 export default function ClientSideNavigationAGIP(props) {
+  const hrefObject = { pathname: '/ssr/b', query: { foo: 'bar' } };
   const href = '/ssr/b?foo=bar';
 
   const { replace } = useRouter();
@@ -12,15 +13,20 @@ export default function ClientSideNavigationAGIP(props) {
   };
 
   const goToPageBObject = () => {
-    replace({ pathname: '/ssr/b', query: { foo: 'bar' } });
+    replace(hrefObject);
   };
 
   return (
     <div>
       <h2>This is page A</h2>
+
       <Link href={href}>
-        <a>Go to B with Link</a>
+        <a>Go to B with Link (with string)</a>
       </Link>
+      <Link href={hrefObject}>
+        <a>Go to B with Link (with object)</a>
+      </Link>
+
       <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
       <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
 

--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -10,10 +10,11 @@ const nextRoot = __dirname + '/__fixtures__';
 
 describe('Client side navigation', () => {
   describe.each`
-    title                               | linkText
-    ${'using Link component'}           | ${'Go to B with Link'}
-    ${'programmatically (with string)'} | ${'Go to B programmatically (with string)'}
-    ${'programmatically (with object)'} | ${'Go to B programmatically (with object)'}
+    title                                   | linkText
+    ${'using Link component (with string)'} | ${'Go to B with Link (with string)'}
+    ${'using Link component (with object)'} | ${'Go to B with Link (with object)'}
+    ${'programmatically (with string)'}     | ${'Go to B programmatically (with string)'}
+    ${'programmatically (with object)'}     | ${'Go to B programmatically (with object)'}
   `('$title', ({ linkText }) => {
     it('navigates between pages', async () => {
       const { render } = await getPage({
@@ -112,7 +113,7 @@ describe('Client side navigation', () => {
     });
 
     const { unmount } = TLRender(page);
-    userEvent.click(screen.getByText('Go to B with Link'));
+    userEvent.click(screen.getByText('Go to B with Link (with string)'));
 
     unmount();
 

--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -10,9 +10,10 @@ const nextRoot = __dirname + '/__fixtures__';
 
 describe('Client side navigation', () => {
   describe.each`
-    title                     | linkText
-    ${'using Link component'} | ${'Go to B with Link'}
-    ${'programmatically'}     | ${'Go to B programmatically'}
+    title                               | linkText
+    ${'using Link component'}           | ${'Go to B with Link'}
+    ${'programmatically (with string)'} | ${'Go to B programmatically (with string)'}
+    ${'programmatically (with object)'} | ${'Go to B programmatically (with object)'}
   `('$title', ({ linkText }) => {
     it('navigates between pages', async () => {
       const { render } = await getPage({
@@ -31,13 +32,13 @@ describe('Client side navigation', () => {
       const { container: expected } = renderWithinNextRoot(
         <PageB
           routerMock={
-            {
-              asPath: '/b',
+            ({
+              asPath: '/b?foo=bar',
               pathname: '/b',
-              query: {},
+              query: { foo: 'bar' },
               route: '/b',
               basePath: '',
-            } as NextRouter
+            } as unknown) as NextRouter
           }
         />
       );
@@ -117,7 +118,7 @@ describe('Client side navigation', () => {
 
     await waitFor(() => {
       expect(warn).toHaveBeenCalledWith(
-        '[next-page-tester] Un-awaited client side navigation from "/a" to "/b". This might lead into unexpected bugs and errors.'
+        '[next-page-tester] Un-awaited client side navigation from "/a" to "/b?foo=bar". This might lead into unexpected bugs and errors.'
       );
     });
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/toomuchdesign/next-page-tester/issues/121

## What is the current behaviour?

Client side navigation with `UrlObject` does not work

## What is the new behaviour?

Client side navigation with `UrlObject` works

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
