### PR TITLE
fix: unmount react components in cleanup

### DIFF
--- a/examples/01-testing-seo.md
+++ b/examples/01-testing-seo.md
@@ -13,6 +13,8 @@ describe('SEO tests', () => {
     });
     serverRender();
 
+    expect(document.title).toEqual('My SEO title');
+
     const html = document.documentElement;
     expect(html).toHaveAttribute('lang', 'en');
 

--- a/src/__tests__/cleanup-dom/__fixtures__/pages/a.tsx
+++ b/src/__tests__/cleanup-dom/__fixtures__/pages/a.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+
+export default function CleanupPageA() {
+  useEffect(() => {
+    return () => {
+      console.warn('Unmounted');
+    };
+  });
+
+  return <div>A</div>;
+}

--- a/src/__tests__/cleanup-dom/cleanup-dom.test.ts
+++ b/src/__tests__/cleanup-dom/cleanup-dom.test.ts
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import { getPage } from '../../../src';
+import { cleanupDOM } from '../../makeRenderMethods';
+
+describe('cleanup-dom', () => {
+  test('unmounts components & teardowns global document objects', async () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => true);
+
+    const initialDocument = document.documentElement.innerHTML;
+    const initialBody = document.body.innerHTML;
+    const initialHead = document.head.innerHTML;
+    const initialTitle = document.title;
+
+    const { render } = await getPage({
+      route: '/a',
+      nextRoot: __dirname + '/__fixtures__',
+    });
+
+    render();
+    expect(screen.getByText('A')).toBeInTheDocument();
+
+    cleanupDOM();
+
+    expect(spy).toHaveBeenCalledWith('Unmounted');
+
+    expect(document.documentElement.innerHTML).toEqual(initialDocument);
+    expect(document.body.innerHTML).toEqual(initialBody);
+    expect(document.head.innerHTML).toEqual(initialHead);
+    expect(document.title).toEqual(initialTitle);
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: unmount react components in DOM cleanup. Implementation taken from [@testing-library/react](https://github.com/testing-library/react-testing-library/blob/master/src/pure.js#L103)

## What is the current behaviour?

DOM is torn down but react components are not unmounted thus cleanup effects are never executed.

## What is the new behaviour?

React components are unmounted

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
