### PR TITLE
fix: throw error on external route redirect

### DIFF
--- a/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
+++ b/src/__tests__/ssr-redirect/ssr-redirect.test.tsx
@@ -7,39 +7,41 @@ describe('ssr-redirect', () => {
   describe.each([['getServerSideProps', 'ssr']])(
     'Page with %s',
     (_dataFetchingType, directory) => {
+      const nextRoot = path.join(__dirname, '__fixtures__', directory);
+
+      it('Throws an error on external redirect', async () => {
+        const redirect = 'https://www.example.com';
+        await expect(
+          getPage({
+            nextRoot,
+            route: `/proxy-page?destination=${redirect}`,
+          })
+        ).rejects.toThrow(`[next-page-tester] External route: ${redirect}`);
+      });
+
       it('Correctly handles single redirect', async () => {
         const { serverRender } = await getPage({
-          nextRoot: path.join(__dirname, '__fixtures__', directory),
+          nextRoot,
           route: '/proxy-to-page-a',
         });
 
         serverRender();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
-    }
-  );
 
-  describe.each([['getServerSideProps', 'ssr']])(
-    'Page with %s',
-    (_dataFetchingType, directory) => {
       it('Correctly handles multiple redirects', async () => {
         const { serverRender } = await getPage({
-          nextRoot: path.join(__dirname, '__fixtures__', directory),
+          nextRoot,
           route: '/proxy-page?destination=/proxy-to-page-a',
         });
 
         serverRender();
         expect(screen.getByText('Page A')).toBeInTheDocument();
       });
-    }
-  );
 
-  describe.each([['getServerSideProps', 'ssr']])(
-    'Page with %s',
-    (_dataFetchingType, directory) => {
       it('Correctly handles multiple redirects after client side navigation', async () => {
         const { render } = await getPage({
-          nextRoot: path.join(__dirname, '__fixtures__', directory),
+          nextRoot,
           route: '/page-b',
         });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,5 +9,3 @@ export enum RuntimeEnvironment {
   SERVER = 'server',
   CLIENT = 'client',
 }
-
-export const ABSOLUTE_URL_REGEXP = new RegExp('^(?:[a-z]+:)?//', 'i');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,5 @@ export enum RuntimeEnvironment {
   SERVER = 'server',
   CLIENT = 'client',
 }
+
+export const ABSOLUTE_URL_REGEXP = new RegExp('^(?:[a-z]+:)?//', 'i');

--- a/src/makePageElement.ts
+++ b/src/makePageElement.ts
@@ -6,14 +6,11 @@ import type {
   PageInfo,
   PageObject,
 } from './commonTypes';
-import { RuntimeEnvironment, ABSOLUTE_URL_REGEXP } from './constants';
+import { RuntimeEnvironment } from './constants';
 import { renderApp } from './_app';
 import { render404Page } from './404';
 import { InternalError } from './_error/error';
-
-function isExternalRoute(route: string) {
-  return Boolean(route.match(ABSOLUTE_URL_REGEXP));
-}
+import { isExternalRoute } from './utils';
 
 /*
  * Return page info associated with a given path

--- a/src/makePageElement.ts
+++ b/src/makePageElement.ts
@@ -6,9 +6,14 @@ import type {
   PageInfo,
   PageObject,
 } from './commonTypes';
-import { RuntimeEnvironment } from './constants';
+import { RuntimeEnvironment, ABSOLUTE_URL_REGEXP } from './constants';
 import { renderApp } from './_app';
 import { render404Page } from './404';
+import { InternalError } from './_error/error';
+
+function isExternalRoute(route: string) {
+  return Boolean(route.match(ABSOLUTE_URL_REGEXP));
+}
 
 /*
  * Return page info associated with a given path
@@ -20,6 +25,9 @@ export async function getPageInfo({
 }): Promise<PageInfo> {
   const pageObject = await getPageObject({ options });
   if (pageObject.type === 'notFound') {
+    if (isExternalRoute(pageObject.route)) {
+      throw new InternalError(`External route: ${pageObject.route}`);
+    }
     return render404Page({ options, pageObject });
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,3 +144,9 @@ export const parseHTML = (html: string) => {
   const domParser = new DOMParser();
   return domParser.parseFromString(html, 'text/html');
 };
+
+const ABSOLUTE_URL_REGEXP = new RegExp('^(?:[a-z]+:)?//', 'i');
+
+export function isExternalRoute(route: string) {
+  return Boolean(route.match(ABSOLUTE_URL_REGEXP));
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix: throw error on external route redirect

## What is the current behaviour?

404 page is rendered when external redirect happens.

## What is the new behaviour?

Error is thrown when external redirect happens.

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
