### PR TITLE
feat: Improve DX by throwing on import failure instead of swallowing …

### DIFF
--- a/src/__tests__/require-error/__fixtures__/pages/_app.tsx
+++ b/src/__tests__/require-error/__fixtures__/pages/_app.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import App from 'next/app';
+
+// @ts-expect-error testing how we handle require errors
+ewqjewqj;
+
+export default class MyApp extends App {
+  render() {
+    const { Component, pageProps } = this.props;
+    return <Component {...pageProps} />;
+  }
+}

--- a/src/__tests__/require-error/__fixtures__/pages/a.tsx
+++ b/src/__tests__/require-error/__fixtures__/pages/a.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function X() {
+  return <></>;
+}

--- a/src/__tests__/require-error/require-error.test.ts
+++ b/src/__tests__/require-error/require-error.test.ts
@@ -1,0 +1,16 @@
+import { getPage } from '../../../src';
+
+const nextRoot = __dirname + '/__fixtures__';
+
+describe('require-error', () => {
+  it('It should throw error with descriptive error message when failing to require _app file', async () => {
+    await expect(
+      getPage({
+        nextRoot,
+        route: '/a',
+      })
+    ).rejects.toThrow(
+      '[next-page-tester] Failed to load "/pages/_app.tsx" file due to ReferenceError: ewqjewqj is not defined'
+    );
+  });
+});

--- a/src/__tests__/require-error/require-error.test.ts
+++ b/src/__tests__/require-error/require-error.test.ts
@@ -10,7 +10,7 @@ describe('require-error', () => {
         route: '/a',
       })
     ).rejects.toThrow(
-      '[next-page-tester] Failed to load "/pages/_app.tsx" file due to ReferenceError: ewqjewqj is not defined'
+      '[next-page-tester] Failed to load "/_app.tsx" file due to ReferenceError: ewqjewqj is not defined'
     );
   });
 });

--- a/src/__tests__/require-error/require-error.test.ts
+++ b/src/__tests__/require-error/require-error.test.ts
@@ -10,7 +10,7 @@ describe('require-error', () => {
         route: '/a',
       })
     ).rejects.toThrow(
-      '[next-page-tester] Failed to load "/_app.tsx" file due to ReferenceError: ewqjewqj is not defined'
+      '[next-page-tester] Failed to load "/_app" file due to ReferenceError: ewqjewqj is not defined'
     );
   });
 });

--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -52,12 +52,8 @@ export function getPageFileIfExists<FileType>({
   try {
     return loadFile({ absolutePath });
   } catch (e) {
-    console.log('absolute: ', absolutePath);
-    console.log('pages dir: ', options.pagesDirectory);
-
-    const relativePath = absolutePath.replace(options.pagesDirectory, '');
     const internalEror = new InternalError(
-      `Failed to load "${relativePath}" file due to ${e.name}: ${e.message}`
+      `Failed to load "${pagePath}" file due to ${e.name}: ${e.message}`
     );
     internalEror.stack = e.stack;
     throw internalEror;

--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -40,21 +40,23 @@ export function getPagePathIfExists(
   }
 }
 
-export function getPageFile<FileType>({
+export function getPageFileIfExists<FileType>({
   pagePath,
   options,
-}: GetPageOptions): FileType {
-  return loadFile({
-    absolutePath: getPagePath({ pagePath, options }),
-  });
-}
-
-export function getPageFileIfExists<FileType>(
-  options: GetPageOptions
-): FileType | undefined {
-  try {
-    return getPageFile(options);
-  } catch (e) {
+}: GetPageOptions): FileType | undefined {
+  const absolutePath = getPagePathIfExists({ pagePath, options });
+  if (!absolutePath) {
     return undefined;
+  }
+
+  try {
+    return loadFile({ absolutePath });
+  } catch (e) {
+    const relativePath = absolutePath.replace(options.nextRoot, '');
+    const internalEror = new InternalError(
+      `Failed to load "${relativePath}" file due to ${e.name}: ${e.message}`
+    );
+    internalEror.stack = e.stack;
+    throw internalEror;
   }
 }

--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import type { ExtendedOptions } from '../commonTypes';
 import { InternalError } from '../_error';
 import { loadFile } from '../loadFile';
+import normalizePath from 'normalize-path';
 
 type GetPageOptions = {
   pagePath: string;
@@ -52,7 +53,10 @@ export function getPageFileIfExists<FileType>({
   try {
     return loadFile({ absolutePath });
   } catch (e) {
-    const relativePath = absolutePath.replace(options.nextRoot, '');
+    const relativePath = normalizePath(absolutePath).replace(
+      options.nextRoot,
+      ''
+    );
     const internalEror = new InternalError(
       `Failed to load "${relativePath}" file due to ${e.name}: ${e.message}`
     );

--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -3,7 +3,6 @@ import { existsSync } from 'fs';
 import type { ExtendedOptions } from '../commonTypes';
 import { InternalError } from '../_error';
 import { loadFile } from '../loadFile';
-import normalizePath from 'normalize-path';
 
 type GetPageOptions = {
   pagePath: string;
@@ -53,10 +52,10 @@ export function getPageFileIfExists<FileType>({
   try {
     return loadFile({ absolutePath });
   } catch (e) {
-    const relativePath = normalizePath(absolutePath).replace(
-      options.nextRoot,
-      ''
-    );
+    console.log('absolute: ', absolutePath);
+    console.log('pages dir: ', options.pagesDirectory);
+
+    const relativePath = absolutePath.replace(options.pagesDirectory, '');
     const internalEror = new InternalError(
       `Failed to load "${relativePath}" file due to ${e.name}: ${e.message}`
     );

--- a/src/page/index.ts
+++ b/src/page/index.ts
@@ -1,7 +1,6 @@
 export { getPageInfo } from './getPageInfo';
 export { makePageElement } from './makePageElement';
 export {
-  getPageFile,
   getPageFileIfExists,
   getPagePath,
   getPagePathIfExists,


### PR DESCRIPTION
…the error

## What kind of change does this PR introduce?

Improves DX. Fixes https://github.com/toomuchdesign/next-page-tester/issues/144

## What is the current behaviour?

Require errors are swallowed, making them extremely hard to debug  the root cause of unexpected behaviour (e.g. custom `_app` not loading). See https://github.com/toomuchdesign/next-page-tester/issues/144 for more details.

## What is the new behaviour?

Require errors are thrown to the user with a nice message/preserved stack:


<img width="893" alt="Screenshot 2021-02-15 at 13 36 06" src="https://user-images.githubusercontent.com/8524109/107947532-c7a01e80-6f92-11eb-8ca0-6d9c1902fb04.png">

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
