### PR TITLE
fix: Default document rendering

### DIFF
--- a/src/__tests__/get-page-return/get-page-return.test.tsx
+++ b/src/__tests__/get-page-return/get-page-return.test.tsx
@@ -6,6 +6,7 @@ import path from 'path';
 import App from './__fixtures__/pages/_app';
 import Page from './__fixtures__/pages/page';
 import { expectDOMElementsToMatch } from '../__utils__';
+import { NEXT_ROOT_ELEMENT_ID } from '../../constants';
 
 // @NOTE These tests are not extensive.
 // They provide a rough idea of the values returned by getPage
@@ -20,15 +21,28 @@ describe('getPage() return', () => {
 
       const expectedPage = (
         <html>
-          <head />
+          <head>
+            <meta name="next-head-count" content="0" />
+            <noscript data-n-css=""></noscript>
+          </head>
           <body>
-            <div id="__next">
+            <div id={NEXT_ROOT_ELEMENT_ID}>
               <App Component={Page} />
             </div>
+            <script
+              id="__NEXT_DATA__"
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html:
+                  '{"page":"/page","query":{},"buildId":"next-page-tester","props":{}}',
+              }}
+            ></script>
           </body>
         </html>
       );
-      const expectedHtml = ReactDOMServer.renderToString(expectedPage);
+
+      const expectedHtml = ReactDOMServer.renderToStaticMarkup(expectedPage);
+
       expect(html).toEqual(expectedHtml);
     });
   });
@@ -40,22 +54,31 @@ describe('getPage() return', () => {
         route: '/page',
       });
       const { nextRoot } = serverRender();
-      const actualNextRoot = document.getElementById('__next');
+      const actualNextRoot = document.getElementById(NEXT_ROOT_ELEMENT_ID);
       expect(nextRoot).toBe(actualNextRoot);
 
       const actualHtml = document.documentElement;
       const { container: expectedHtml } = TLRender(
         <>
-          <head />
+          <head>
+            <meta name="next-head-count" content="0" />
+            <noscript data-n-css=""></noscript>
+          </head>
           <body>
-            <div id="__next">
+            <div id={NEXT_ROOT_ELEMENT_ID}>
               <App Component={Page} />
             </div>
+            <script
+              id="__NEXT_DATA__"
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html:
+                  '{"page":"/page","query":{},"buildId":"next-page-tester","props":{}}',
+              }}
+            ></script>
           </body>
         </>,
-        {
-          container: document.createElement('html'),
-        }
+        { container: document.createElement('html') }
       );
 
       expectDOMElementsToMatch(actualHtml, expectedHtml);
@@ -79,22 +102,31 @@ describe('getPage() return', () => {
         route: '/page',
       });
       const { nextRoot } = render();
-      const actualNextRoot = document.getElementById('__next');
+      const actualNextRoot = document.getElementById(NEXT_ROOT_ELEMENT_ID);
       expect(nextRoot).toBe(actualNextRoot);
 
       const actualHtml = document.documentElement;
       const { container: expectedHtml } = TLRender(
         <>
-          <head />
+          <head>
+            <meta name="next-head-count" content="0" />
+            <noscript data-n-css=""></noscript>
+          </head>
           <body>
-            <div id="__next">
+            <div id={NEXT_ROOT_ELEMENT_ID}>
               <App Component={Page} />
             </div>
+            <script
+              id="__NEXT_DATA__"
+              type="application/json"
+              dangerouslySetInnerHTML={{
+                __html:
+                  '{"page":"/page","query":{},"buildId":"next-page-tester","props":{}}',
+              }}
+            ></script>
           </body>
         </>,
-        {
-          container: document.createElement('html'),
-        }
+        { container: document.createElement('html') }
       );
 
       expectDOMElementsToMatch(actualHtml, expectedHtml);

--- a/src/__tests__/use-document/__fixtures__/default-document-with-page-head-title/pages/_document.tsx
+++ b/src/__tests__/use-document/__fixtures__/default-document-with-page-head-title/pages/_document.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+} from 'next/document';
+import { RenderPageResult } from 'next/dist/next-server/lib/utils';
+
+type Props = RenderPageResult & {
+  description: string;
+};
+
+class CustomDocument extends Document<Props> {
+  static getInitialProps = async (ctx: DocumentContext) => {
+    const initialProps = await Document.getInitialProps(ctx);
+    return {
+      ...initialProps,
+      description: 'Custom document description',
+    };
+  };
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <meta name="description" content={this.props.description} />
+        </Head>
+
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default CustomDocument;

--- a/src/__tests__/use-document/__fixtures__/default-document-with-page-head-title/pages/page.tsx
+++ b/src/__tests__/use-document/__fixtures__/default-document-with-page-head-title/pages/page.tsx
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+import Head from 'next/head';
+
+export default function CustomDocumentWithPageHeadTitle() {
+  const [count, setCount] = useState(0);
+  return (
+    <>
+      <Head>
+        <title>Server Side Title</title>
+      </Head>
+      <span>/default-document-with-page-head-title/page</span>
+      <button onClick={() => setCount((prev) => prev + 1)}>Count me!</button>
+      <div>Count: {count}</div>
+    </>
+  );
+}

--- a/src/__tests__/use-document/use-document.test.tsx
+++ b/src/__tests__/use-document/use-document.test.tsx
@@ -5,6 +5,8 @@ import path from 'path';
 import { getPage } from '../../../src';
 import { expectDOMElementsToMatch } from '../__utils__';
 import CustomDocumentWithGIP_Page from './__fixtures__/custom-document-with-gip/pages/page';
+import DefaultDocumentWithPageHeadTitle from './__fixtures__/default-document-with-page-head-title/pages/page';
+
 import CustomApp from './__fixtures__/custom-document-with-gip/pages/_app';
 import { getMetaTagsContentByName } from '../__utils__/_document';
 
@@ -48,19 +50,62 @@ describe('_document support', () => {
     });
   });
 
-  describe('useCustomDocument === false', () => {
-    it('renders default empty document', async () => {
+  describe('useDocument === false', () => {
+    it('render default document with page head title', async () => {
       const { serverRender } = await getPage({
-        nextRoot: __dirname + '/__fixtures__/custom-document-with-gip',
+        nextRoot: path.join(
+          __dirname,
+          '__fixtures__',
+          'default-document-with-page-head-title'
+        ),
         route: '/page',
-        useDocument: false,
       });
       serverRender();
 
       const actual = document.documentElement;
       const { container: expected } = render(
         <>
-          <head></head>
+          <head>
+            <meta name="viewport" content="width=device-width" />
+            <meta charSet="utf-8" />
+            <title>Server Side Title</title>
+            <meta name="next-head-count" content="3" />
+            <noscript data-n-css=""></noscript>
+          </head>
+          <body>
+            <div id="__next">
+              <DefaultDocumentWithPageHeadTitle />
+            </div>
+            <script
+              id="__NEXT_DATA__"
+              type="application/json"
+            >{`{"page":"/page","query":{},"buildId":"next-page-tester","props":{}}`}</script>
+          </body>
+        </>,
+        { container: document.createElement('html') }
+      );
+
+      expectDOMElementsToMatch(actual, expected);
+      expect(document.title).toEqual('Server Side Title');
+    });
+
+    it('renders default document', async () => {
+      const { serverRender } = await getPage({
+        nextRoot: __dirname + '/__fixtures__/custom-document-with-gip',
+        route: '/page',
+      });
+      serverRender();
+
+      const actual = document.documentElement;
+      const { container: expected } = render(
+        <>
+          <head>
+            <meta name="viewport" content="width=device-width" />
+            <meta charSet="utf-8" />
+            <meta name="description" content="Page description" />
+            <meta name="next-head-count" content="3" />
+            <noscript data-n-css=""></noscript>
+          </head>
           <body>
             <div id="__next">
               <CustomApp
@@ -68,6 +113,10 @@ describe('_document support', () => {
                 pageProps={{}}
               />
             </div>
+            <script
+              id="__NEXT_DATA__"
+              type="application/json"
+            >{`{"page":"/page","query":{},"buildId":"next-page-tester","props":{}}`}</script>
           </body>
         </>,
         { container: document.createElement('html') }

--- a/src/_document/getDocumentFile.ts
+++ b/src/_document/getDocumentFile.ts
@@ -8,15 +8,17 @@ export function getDocumentFile({
 }: {
   options: ExtendedOptions;
 }): NextDocumentFile {
-  const customDocumentFile = getPageFileIfExists<NextDocumentFile>({
-    options,
-    pagePath: DOCUMENT_PATH,
-  });
+  const { useDocument } = options;
+  if (useDocument) {
+    const customDocumentFile = getPageFileIfExists<NextDocumentFile>({
+      options,
+      pagePath: DOCUMENT_PATH,
+    });
 
-  if (customDocumentFile) {
-    return customDocumentFile;
+    if (customDocumentFile) {
+      return customDocumentFile;
+    }
   }
-
   return getDefaultDocumentFile();
 }
 

--- a/src/_document/render.tsx
+++ b/src/_document/render.tsx
@@ -12,7 +12,7 @@ import type {
   NextComponentType,
   RenderPage,
 } from 'next/dist/next-server/lib/utils';
-import { APP_PATH, NEXT_ROOT_ELEMENT_ID } from '../constants';
+import { APP_PATH } from '../constants';
 import { renderToString } from 'react-dom/server';
 import { HeadManagerContext } from 'next/dist/next-server/lib/head-manager-context';
 import type { DocumentProps } from 'next/document';
@@ -57,7 +57,6 @@ export default async function serverRenderDocument({
   wrapWithRouter: (children: JSX.Element) => JSX.Element;
 }): Promise<JSX.Element> {
   return executeAsIfOnServer(async () => {
-    const { useDocument } = options;
     const {
       documentFile: { default: DocumentComponent },
       appFile: { default: AppComponent },
@@ -67,20 +66,6 @@ export default async function serverRenderDocument({
     const render = (App: NextApp, Page: NextPage) => {
       return renderEnhancedApp({ App, Page, options, pageProps });
     };
-
-    // Return an empty dummy document if useDocument is not enabled
-    if (!useDocument) {
-      return (
-        <html>
-          <head></head>
-          <body>
-            <div id={NEXT_ROOT_ELEMENT_ID}>
-              {wrapWithRouter(render(AppComponent, PageComponent))}
-            </div>
-          </body>
-        </html>
-      );
-    }
 
     const renderPage: RenderPage = (options = {}) => {
       const {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix default document rendering.

Fixes https://github.com/toomuchdesign/next-page-tester/issues/154

## What is the current behaviour?

When `useDocument=false` we didn't properly render the Next.JS document (we skipped it) which meant that any `SEO` elements defined in custom `_app` or in `page` were not rendered.

This is wrong behaviour that is not in line with `useApp` where this flag only controls if we should use custom `_app` component, but not changing the rendering flow.

## What is the new behaviour?

`useDocument=false` is now inline with the `useApp=false` behaviour and document rendering flow is always correct.

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
