### PR TITLE
fix: client side SingletonRouter

### DIFF
--- a/src/__tests__/client-navigation/__fixtures__/PageA.tsx
+++ b/src/__tests__/client-navigation/__fixtures__/PageA.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { UrlObject } from 'url';
-import { useRouter } from 'next/router';
+import Router, { useRouter } from 'next/router';
 
 type Props = {
   href: string;
@@ -10,14 +10,6 @@ type Props = {
 
 export const PageA = ({ href, hrefObject }: Props) => {
   const { replace } = useRouter();
-
-  const goToPageBstring = () => {
-    replace(href);
-  };
-
-  const goToPageBObject = () => {
-    replace(hrefObject);
-  };
 
   return (
     <div>
@@ -30,8 +22,19 @@ export const PageA = ({ href, hrefObject }: Props) => {
         <a>Go to B with Link (with object)</a>
       </Link>
 
-      <a onClick={goToPageBstring}>Go to B programmatically (with string)</a>
-      <a onClick={goToPageBObject}>Go to B programmatically (with object)</a>
+      <a onClick={() => Router.replace(href)}>
+        Go to B programmatically (next/router - with string)
+      </a>
+      <a onClick={() => Router.replace(hrefObject)}>
+        Go to B programmatically (next/router - with object)
+      </a>
+
+      <a onClick={() => replace(href)}>
+        Go to B programmatically (useRouter - with string)
+      </a>
+      <a onClick={() => replace(hrefObject)}>
+        Go to B programmatically (useRouter - with object)
+      </a>
     </div>
   );
 };

--- a/src/__tests__/client-navigation/client-navigation.test.tsx
+++ b/src/__tests__/client-navigation/client-navigation.test.tsx
@@ -10,11 +10,13 @@ const nextRoot = __dirname + '/__fixtures__';
 
 describe('Client side navigation', () => {
   describe.each`
-    title                                   | linkText
-    ${'using Link component (with string)'} | ${'Go to B with Link (with string)'}
-    ${'using Link component (with object)'} | ${'Go to B with Link (with object)'}
-    ${'programmatically (with string)'}     | ${'Go to B programmatically (with string)'}
-    ${'programmatically (with object)'}     | ${'Go to B programmatically (with object)'}
+    title                                             | linkText
+    ${'using Link component (with string)'}           | ${'Go to B with Link (with string)'}
+    ${'using Link component (with object)'}           | ${'Go to B with Link (with object)'}
+    ${'programmatically (next/router - with string)'} | ${'Go to B programmatically (next/router - with string)'}
+    ${'programmatically (next/router - with object)'} | ${'Go to B programmatically (next/router - with object)'}
+    ${'programmatically (useRouter - with string)'}   | ${'Go to B programmatically (useRouter - with string)'}
+    ${'programmatically (useRouter - with object)'}   | ${'Go to B programmatically (useRouter - with object)'}
   `('$title', ({ linkText }) => {
     it('navigates between pages', async () => {
       const { render } = await getPage({

--- a/src/router/makeRouterMock.ts
+++ b/src/router/makeRouterMock.ts
@@ -73,21 +73,24 @@ export default function makeRouterMock({
   return SingletonRouter;
 }
 
+function getSingletonRouter() {
+  return SingletonRouter;
+}
+
+function createSingletonRouter() {
+  return Object.assign(getSingletonRouter, {
+    events: {
+      on: () => {},
+      off: () => {},
+      emit: () => {},
+    },
+  });
+}
+
 jest.mock('next/dist/next-server/lib/router/router', () => ({
   __esModule: true,
   ...jest.requireActual<Record<string, unknown>>(
     'next/dist/next-server/lib/router/router'
   ),
-  default: Object.assign(
-    function () {
-      return SingletonRouter;
-    },
-    {
-      events: {
-        on: () => {},
-        off: () => {},
-        emit: () => {},
-      },
-    }
-  ),
+  default: createSingletonRouter(),
 }));

--- a/src/router/makeRouterMock.ts
+++ b/src/router/makeRouterMock.ts
@@ -1,8 +1,9 @@
-import type { NextRouter } from 'next/router';
+import { createRouter, NextRouter } from 'next/router';
 import { removeFileExtension, parseRoute } from '../utils';
 import type { ExtendedOptions, PageObject } from '../commonTypes';
 
 type NextPushArgs = Parameters<NextRouter['push']>;
+
 export type PushHandler = (
   url: NextPushArgs[0],
   as: NextPushArgs[1],
@@ -44,6 +45,8 @@ function makeDefaultRouterMock({
   return routerMock;
 }
 
+let SingletonRouter: NextRouter;
+
 export default function makeRouterMock({
   options: { router: routerEnhancer },
   pageObject: { pagePath, params, route, query },
@@ -63,5 +66,28 @@ export default function makeRouterMock({
     basePath: '',
   };
 
-  return routerEnhancer(router);
+  SingletonRouter = routerEnhancer(router);
+  // @ts-expect-error we are calling this just to execute the initialization of singletonRouter which we
+  // intercept and assign to our mocked router
+  createRouter();
+  return SingletonRouter;
 }
+
+jest.mock('next/dist/next-server/lib/router/router', () => ({
+  __esModule: true,
+  ...jest.requireActual<Record<string, unknown>>(
+    'next/dist/next-server/lib/router/router'
+  ),
+  default: Object.assign(
+    function () {
+      return SingletonRouter;
+    },
+    {
+      events: {
+        on: () => {},
+        off: () => {},
+        emit: () => {},
+      },
+    }
+  ),
+}));


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enables client side `SingletonRouter`  routing exported from `next/router`.

Fixes https://github.com/toomuchdesign/next-page-tester/issues/160

## What is the current behaviour?

It is not possible to use client side `SingletonRouter`  routing exported from `next/router`.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
