### PR TITLE
Auto init test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ React element of the application.
 | **dotenvFile**                 | Relative path to a `.env` file holding [environment variables][next-docs-env-vars] | `string`                          | -               |
 | **wrapper**                    | Map of render functions. Useful to decorate component tree with mocked providers.  | `{ Page?: NextPage => NextPage }` | -               |
 
-## Set up your test environment
+## Skipping Auto Cleanup & Helpers Initialisation
 
 Since Next.js is not designed to run in a JSDOM environment we need to **setup the default JSDOM** to allow a smoother testing experience:
 
 - Provide a `window.scrollTo` mock
 - Provide a `IntersectionObserver` mock
 - Cleanup DOM after each test
+- Isolate some React modules to preserve their identity between "server" and "client" execution
 
-Run [`initTestHelpers`](/src/testHelpers.ts) in your global tests setup (in case of Jest It is `setupFilesAfterEnv` file):
+However, you may choose to skip the auto cleanup by setting the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'. You can do this with cross-env like so:
 
 ```js
-import { initTestHelpers } from 'next-page-tester';
-initTestHelpers();
+cross-env NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS=true jest
 ```
 
 ### Handling special imports

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Since Next.js is not designed to run in a JSDOM environment we need to **setup t
 - Cleanup DOM after each test
 - Isolate some React modules to preserve their identity between "server" and "client" execution
 
-However, you may choose to skip the auto cleanup by setting the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'. You can do this with cross-env like so:
+However, you may choose to skip the auto cleanup & helpers initialisation by setting the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'. You can do this with cross-env like so:
 
 ```js
 cross-env NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS=true jest

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ React element of the application.
 
 ## Skipping Auto Cleanup & Helpers Initialisation
 
-Since Next.js is not designed to run in a JSDOM environment we need to **setup the default JSDOM** to allow a smoother testing experience:
+Since Next.js is not designed to run in a JSDOM environment we need to **setup the default JSDOM** to allow a smoother testing experience. By default, `next-page-tester` will:
 
 - Provide a `window.scrollTo` mock
 - Provide a `IntersectionObserver` mock

--- a/README.md
+++ b/README.md
@@ -111,15 +111,14 @@ React element of the application.
 
 Since Next.js is not designed to run in a JSDOM environment we need to **setup the default JSDOM** to allow a smoother testing experience. By default, `next-page-tester` will:
 
-- Provide a `window.scrollTo` mock
-- Provide a `IntersectionObserver` mock
+- Provide `window.scrollTo` and `IntersectionObserver` mocks
 - Cleanup DOM after each test
-- Isolate some React modules to preserve their identity between "server" and "client" execution
+- Setup jest to preserve the identity of some specific modules between "server" and "client" execution
 
-However, you may choose to skip the auto cleanup & helpers initialisation by setting the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'. You can do this with cross-env like so:
+However, you may choose to skip the auto cleanup & helpers initialisation by setting the NPT_SKIP_AUTO_SETUP env variable to 'true'. You can do this with cross-env like so:
 
 ```js
-cross-env NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS=true jest
+cross-env NPT_SKIP_AUTO_SETUP=true jest
 ```
 
 ### Handling special imports

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,7 +1,4 @@
 import '@testing-library/jest-dom';
-// @NOTE Import path must finish with "./src" to correctly configure /dist tests
-import { initTestHelpers } from '../../src';
-initTestHelpers();
 
 afterEach(() => {
   // Clear all cookies

--- a/src/__tests__/test-helpers/__fixtures__/pages/index.tsx
+++ b/src/__tests__/test-helpers/__fixtures__/pages/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function IndexPage() {
+  return <>Index Page</>;
+}

--- a/src/__tests__/test-helpers/test-helpers.test.ts
+++ b/src/__tests__/test-helpers/test-helpers.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import { screen } from '@testing-library/react';
+
+describe('test-helpers', () => {
+  describe('Should skip auto init test helpers', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let getPage: any;
+
+    beforeAll(() => {
+      process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS = 'true';
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const npt = require('../../../src');
+      getPage = npt.getPage;
+    });
+
+    test('first', async () => {
+      const { render } = await getPage({
+        route: '/',
+        nextRoot: path.join(__dirname, '__fixtures__'),
+      });
+      render();
+      await screen.findByText('Index Page');
+    });
+
+    test('second', async () => {
+      await screen.findByText('Index Page');
+    });
+  });
+});

--- a/src/__tests__/test-helpers/test-helpers.test.ts
+++ b/src/__tests__/test-helpers/test-helpers.test.ts
@@ -7,7 +7,7 @@ describe('test-helpers', () => {
     let getPage: any;
 
     beforeAll(() => {
-      process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS = 'true';
+      process.env.NPT_SKIP_AUTO_SETUP = 'true';
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const npt = require('../../../src');
       getPage = npt.getPage;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { initTestHelpers } from './pure';
 // then we'll automatically init test helpers and run cleanup afterEach test
 // this ensures that tests run in isolation from each other
 // if you don't like this then either import the `pure` module
-// or set the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'.
-if (!process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS) {
+// or set the NPT_SKIP_AUTO_SETUP env variable to 'true'.
+if (!process.env.NPT_SKIP_AUTO_SETUP) {
   initTestHelpers();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import { initTestHelpers } from './pure';
 // this ensures that tests run in isolation from each other
 // if you don't like this then either import the `pure` module
 // or set the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'.
-/* istanbul ignore else */
 if (!process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS) {
   initTestHelpers();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { initTestHelpers } from './pure';
 // this ensures that tests run in isolation from each other
 // if you don't like this then either import the `pure` module
 // or set the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'.
+/* istanbul ignore else */
 if (!process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS) {
   initTestHelpers();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,12 @@
-export { default as getPage } from './getPage';
-export { initTestHelpers, cleanup } from './testHelpers';
+export * from './pure';
+
+import { initTestHelpers } from './pure';
+
+// if we're running in a test runner that supports afterEach
+// then we'll automatically init test helpers and run cleanup afterEach test
+// this ensures that tests run in isolation from each other
+// if you don't like this then either import the `pure` module
+// or set the NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS env variable to 'true'.
+if (!process.env.NEXT_PAGE_TESTER_SKIP_AUTO_INIT_TEST_HELPERS) {
+  initTestHelpers();
+}

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,0 +1,2 @@
+export { default as getPage } from './getPage';
+export { initTestHelpers, cleanup } from './testHelpers';

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -28,7 +28,9 @@ export function initTestHelpers() {
     afterEach(cleanup);
   }
 
-  if (typeof beforeAll === 'function') {
+  // We are intentionally only targeting jest here for it to work with jest.isolatedModules
+  // If user has a different test runner we handle it in src/utils where we fallback to stealthy-require
+  if (typeof jest !== 'undefined') {
     beforeAll(() => {
       for (const moduleName of nonIsolatedModules) {
         // @NOTE for some reason Jest needs us to pre-import the modules

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -28,7 +28,7 @@ export function initTestHelpers() {
     afterEach(cleanup);
   }
 
-  if (typeof jest !== 'undefined') {
+  if (typeof beforeAll === 'function') {
     beforeAll(() => {
       for (const moduleName of nonIsolatedModules) {
         // @NOTE for some reason Jest needs us to pre-import the modules


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Improves DX by setting up auto cleanup & test initialisation

## What is the current behaviour?

User has to manually call `initTestHelpers` in their testing setup to avoid errors at runtime.

## What is the new behaviour?

Users don't have to do anything. They can directly use `next-page-tester` imports and everything will work out of the box.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
