### PR TITLE
fix: revive nonIsolatedModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ React element of the application.
 | **nextRoot**                   | Absolute path to Next.js root folder                                               | `string`                          | _auto detected_ |
 | **dotenvFile**                 | Relative path to a `.env` file holding [environment variables][next-docs-env-vars] | `string`                          | -               |
 | **wrapper**                    | Map of render functions. Useful to decorate component tree with mocked providers.  | `{ Page?: NextPage => NextPage }` | -               |
+| **nonIsolatedModules**         | List of modules that should preserve identity between client and server context.   | `string[]`                        | []              |
 
 ## Skipping Auto Cleanup & Helpers Initialisation
 
@@ -157,6 +158,25 @@ Under [examples folder][examples-folder] we're documenting the testing cases whi
 | v0.8.0 +         | v10.X.X |
 
 ## FAQ
+
+### How do I mock API calls in my data fetching methods?
+
+Because `next-page-tester` isolates modules between "client" and "server" context, mocks that are set in test (client context) wont apply in data fetching methods (server context).
+To overcome that, we need to "taint" such modules to preserve identity between "client" and "server" context by passing them through the `nonIsolatedModules` option.
+
+```ts
+test('as a user I want to mock a module in client & server environment', async () => {
+  const stub = jest.spyOn(api, 'getData').mockReturnValue(Promise.resolve('data'))
+
+  const { render } = await getPage({
+    route: '/page',
+    nextRoot,
+    nonIsolatedModules: [path.join(nextRoot, 'api')],
+  });
+
+  expect(stub).toHaveBeenCalledTimes(1); // this was executed in your data fetching method
+}
+```
 
 ### How do I make cookies available in Next.js data fetching methods?
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ React element of the application.
 | **nextRoot**                   | Absolute path to Next.js root folder                                               | `string`                          | _auto detected_ |
 | **dotenvFile**                 | Relative path to a `.env` file holding [environment variables][next-docs-env-vars] | `string`                          | -               |
 | **wrapper**                    | Map of render functions. Useful to decorate component tree with mocked providers.  | `{ Page?: NextPage => NextPage }` | -               |
-| **nonIsolatedModules**         | List of modules that should preserve identity between client and server context.   | `string[]`                        | []              |
+| **sharedModules**              | List of modules that should preserve identity between client and server context.   | `string[]`                        | []              |
 
 ## Skipping Auto Cleanup & Helpers Initialisation
 
@@ -161,8 +161,8 @@ Under [examples folder][examples-folder] we're documenting the testing cases whi
 
 ### How do I mock API calls in my data fetching methods?
 
-Because `next-page-tester` isolates modules between "client" and "server" context mocks that are created in test (client context) wont execute in data fetching methods (server context).
-To overcome that, we need to "taint" such modules to preserve identity between "client" and "server" context by passing them through the `nonIsolatedModules` option.
+Since `next-page-tester` isolates modules between "client" and "server" context mocks that are created in test (client context) won't execute in data fetching methods (server context).
+To overcome that, we need to "taint" such modules to (preserve/share) their identity between "client" and "server" context by passing them through the `sharedModules` option.
 
 ```ts
 test('as a user I want to mock a module in client & server environment', async () => {
@@ -171,7 +171,7 @@ test('as a user I want to mock a module in client & server environment', async (
   const { render } = await getPage({
     route: '/page',
     nextRoot,
-    nonIsolatedModules: [`${process.cwd()}/src/path/to/my/module`],
+    sharedModules: [`${process.cwd()}/src/path/to/my/module`],
   });
 
   expect(stub).toHaveBeenCalledTimes(1); // this was executed in your data fetching method

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Under [examples folder][examples-folder] we're documenting the testing cases whi
 
 ### How do I mock API calls in my data fetching methods?
 
-Because `next-page-tester` isolates modules between "client" and "server" context, mocks that are set in test (client context) wont apply in data fetching methods (server context).
+Because `next-page-tester` isolates modules between "client" and "server" context mocks that are created in test (client context) wont execute in data fetching methods (server context).
 To overcome that, we need to "taint" such modules to preserve identity between "client" and "server" context by passing them through the `nonIsolatedModules` option.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ test('as a user I want to mock a module in client & server environment', async (
   const { render } = await getPage({
     route: '/page',
     nextRoot,
-    nonIsolatedModules: [path.join(nextRoot, 'api')],
+    nonIsolatedModules: [`${process.cwd()}/src/path/to/my/module`],
   });
 
   expect(stub).toHaveBeenCalledTimes(1); // this was executed in your data fetching method

--- a/src/__tests__/non-isolated-modules/__fixtures__/api.ts
+++ b/src/__tests__/non-isolated-modules/__fixtures__/api.ts
@@ -1,0 +1,3 @@
+export const getData = async () => {
+  return 'data-from-module';
+};

--- a/src/__tests__/non-isolated-modules/__fixtures__/pages/page.tsx
+++ b/src/__tests__/non-isolated-modules/__fixtures__/pages/page.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import * as api from '../api';
+import type { GetServerSideProps } from 'next';
+
+type Props = {
+  data: string;
+};
+
+export default function Page({ data: initialData }: Props) {
+  const [data, setData] = useState(initialData);
+
+  const handleClick = () => {
+    api.getData().then(setData);
+  };
+
+  return (
+    <>
+      <span>{data}</span>
+      <button onClick={handleClick}>Change data</button>
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {
+      data: await api.getData(),
+    },
+  };
+};

--- a/src/__tests__/non-isolated-modules/non-isolated-modules.test.ts
+++ b/src/__tests__/non-isolated-modules/non-isolated-modules.test.ts
@@ -16,7 +16,7 @@ describe('non-isolated-modules', () => {
     const { render } = await getPage({
       route: '/page',
       nextRoot,
-      nonIsolatedModules: [path.join(nextRoot, 'api')],
+      sharedModules: [path.join(nextRoot, 'api')],
     });
 
     expect(stub).toHaveBeenCalledTimes(1);

--- a/src/__tests__/non-isolated-modules/non-isolated-modules.test.ts
+++ b/src/__tests__/non-isolated-modules/non-isolated-modules.test.ts
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import path from 'path';
+import * as api from './__fixtures__/api';
+import { getPage } from '../../../src';
+
+const nextRoot = path.join(__dirname, '__fixtures__');
+
+describe('non-isolated-modules', () => {
+  test('as a user I want to mock a module in client & server environment', async () => {
+    const stub = jest
+      .spyOn(api, 'getData')
+      .mockReturnValueOnce(Promise.resolve('mocked-server-data'))
+      .mockReturnValueOnce(Promise.resolve('mocked-client-data'));
+
+    const { render } = await getPage({
+      route: '/page',
+      nextRoot,
+      nonIsolatedModules: [path.join(nextRoot, 'api')],
+    });
+
+    expect(stub).toHaveBeenCalledTimes(1);
+
+    render();
+    await screen.findByText('mocked-server-data');
+
+    userEvent.click(screen.getByText('Change data'));
+    await screen.findByText('mocked-client-data');
+
+    expect(stub).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -21,7 +21,7 @@ export type ResEnhancer = (res: Res) => Res;
 
 export type Options = {
   route: string;
-  nonIsolatedModules?: string[];
+  sharedModules?: string[];
   nextRoot?: string;
   req?: ReqEnhancer;
   res?: ResEnhancer;

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -21,6 +21,7 @@ export type ResEnhancer = (res: Res) => Res;
 
 export type Options = {
   route: string;
+  nonIsolatedModules?: string[];
   nextRoot?: string;
   req?: ReqEnhancer;
   res?: ResEnhancer;

--- a/src/getNextFiles.ts
+++ b/src/getNextFiles.ts
@@ -39,8 +39,9 @@ export function loadExistingPageFiles({
   return {
     client: loadPageFiles({ absolutePagePath, options }),
     server: executeAsIfOnServerSync(() =>
-      executeWithFreshModules(() =>
-        loadPageFiles({ absolutePagePath, options })
+      executeWithFreshModules(
+        () => loadPageFiles({ absolutePagePath, options }),
+        options
       )
     ),
   };
@@ -56,8 +57,9 @@ export function loadErrorPageFiles({
   return {
     client: loadPageFiles({ absolutePagePath, options }),
     server: executeAsIfOnServerSync(() =>
-      executeWithFreshModules(() =>
-        loadPageFiles({ absolutePagePath, options })
+      executeWithFreshModules(
+        () => loadPageFiles({ absolutePagePath, options }),
+        options
       )
     ),
   };

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -47,6 +47,7 @@ export default async function getPage({
   useDocument = false,
   dotenvFile,
   wrapper,
+  nonIsolatedModules = [],
 }: Options): Promise<
   { page: React.ReactElement } & ReturnType<typeof makeRenderMethods>
 > {
@@ -60,6 +61,7 @@ export default async function getPage({
     useDocument,
     dotenvFile,
     wrapper,
+    nonIsolatedModules,
   };
 
   validateOptions(optionsWithDefaults);

--- a/src/getPage.tsx
+++ b/src/getPage.tsx
@@ -47,7 +47,7 @@ export default async function getPage({
   useDocument = false,
   dotenvFile,
   wrapper,
-  nonIsolatedModules = [],
+  sharedModules = [],
 }: Options): Promise<
   { page: React.ReactElement } & ReturnType<typeof makeRenderMethods>
 > {
@@ -61,7 +61,7 @@ export default async function getPage({
     useDocument,
     dotenvFile,
     wrapper,
-    nonIsolatedModules,
+    sharedModules,
   };
 
   validateOptions(optionsWithDefaults);

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -1,6 +1,6 @@
 import { cleanupDOM } from './makeRenderMethods';
 import { cleanupEnvVars } from './setEnvVars';
-import { nonIsolatedModules } from './utils';
+import { unIsolatePredefinedJestModules } from './utils';
 
 function isJSDOMEnvironment() {
   return navigator && navigator.userAgent.includes('jsdom');
@@ -31,14 +31,7 @@ export function initTestHelpers() {
   // We are intentionally only targeting jest here for it to work with jest.isolatedModules
   // If user has a different test runner we handle it in src/utils where we fallback to stealthy-require
   if (typeof jest !== 'undefined') {
-    beforeAll(() => {
-      for (const moduleName of nonIsolatedModules) {
-        // @NOTE for some reason Jest needs us to pre-import the modules
-        // we want to require with jest.requireActual
-        require(moduleName);
-        jest.mock(moduleName, () => jest.requireActual(moduleName));
-      }
-    });
+    unIsolatePredefinedJestModules();
   }
 }
 

--- a/src/testHelpers.ts
+++ b/src/testHelpers.ts
@@ -1,6 +1,6 @@
 import { cleanupDOM } from './makeRenderMethods';
 import { cleanupEnvVars } from './setEnvVars';
-import { unIsolatePredefinedJestModules } from './utils';
+import { preservePredefinedSharedModulesIdentity } from './utils';
 
 function isJSDOMEnvironment() {
   return navigator && navigator.userAgent.includes('jsdom');
@@ -31,7 +31,7 @@ export function initTestHelpers() {
   // We are intentionally only targeting jest here for it to work with jest.isolatedModules
   // If user has a different test runner we handle it in src/utils where we fallback to stealthy-require
   if (typeof jest !== 'undefined') {
-    unIsolatePredefinedJestModules();
+    preservePredefinedSharedModulesIdentity();
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,16 +90,16 @@ export function useMountedState(): () => boolean {
 }
 
 // @NOTE: It is crucial that these modules preserve their identity between client and server
-// for document rendering to work correctly. For things to kick in early enough we un isolate
-// them in testHelpers.
-const predefinedNonIsolatedModules = [
+// for document rendering to work correctly. For things to kick in early enough in the process we
+// mark them as such in testHelpers.
+const predefinedSharedModules = [
   'react',
   'next/dist/next-server/lib/head-manager-context',
   'next/dist/next-server/lib/router-context',
   'next/dist/next-server/lib/runtime-config',
 ];
 
-function unIsolateJestModules(modules: string[]) {
+function preserveJestSharedModulesIdentity(modules: string[]) {
   for (const moduleName of modules) {
     // @NOTE for some reason Jest needs us to pre-import the modules
     // we want to require with jest.requireActual
@@ -108,19 +108,19 @@ function unIsolateJestModules(modules: string[]) {
   }
 }
 
-export function unIsolatePredefinedJestModules() {
-  unIsolateJestModules(predefinedNonIsolatedModules);
+export function preservePredefinedSharedModulesIdentity() {
+  preserveJestSharedModulesIdentity(predefinedSharedModules);
 }
 
 export function executeWithFreshModules<T>(
   f: () => T,
-  { nonIsolatedModules }: { nonIsolatedModules: string[] }
+  { sharedModules }: { sharedModules: string[] }
 ): T {
   /* istanbul ignore else */
   if (typeof jest !== 'undefined') {
     let result: T;
 
-    unIsolateJestModules(nonIsolatedModules);
+    preserveJestSharedModulesIdentity(sharedModules);
 
     jest.isolateModules(() => {
       result = f();
@@ -135,8 +135,8 @@ export function executeWithFreshModules<T>(
       f,
       () => {
         for (const moduleName of [
-          ...predefinedNonIsolatedModules,
-          ...nonIsolatedModules,
+          ...predefinedSharedModules,
+          ...sharedModules,
         ]) {
           require(moduleName);
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Re-introduce `nonIsolatedModules` option. This enables module mocking in "server" context.

## What is the current behaviour?

It is not possible to mock a module (e.g. SDK) in "server" context. Because test is executed in "client" context any mocks configured in test code are not applied to "server" context.

## What is the new behaviour?

Add ability to mark such modules as "nonIsolated". Identity of those modules is then preserved in both contexts and mocking is possible.

## Does this PR introduce a breaking change?

No

## Other information:


## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
