### PR TITLE
feat: Polyfill, fetch on server-env

### DIFF
--- a/src/__tests__/__utils__/fetcher.ts
+++ b/src/__tests__/__utils__/fetcher.ts
@@ -1,0 +1,2 @@
+export const fetcher = (resource: string) =>
+  fetch(resource).catch(() => resource);

--- a/src/__tests__/__utils__/index.ts
+++ b/src/__tests__/__utils__/index.ts
@@ -10,3 +10,4 @@ export {
 export { expectToBeDefault404Page } from './expectToBeDefault404Page';
 export { renderWithinNextRoot } from './renderWithinNextRoot';
 export { silenceConsoleError } from './silenceConsoleError';
+export { fetcher } from './fetcher';

--- a/src/__tests__/page-data-fetching/__fixtures__/pages/ssr/[id].js
+++ b/src/__tests__/page-data-fetching/__fixtures__/pages/ssr/[id].js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PropsPrinter, sleep } from '../../../../__utils__';
+import { fetcher, PropsPrinter, sleep } from '../../../../__utils__';
 
 export default function ssr_$id$(props) {
   return (
@@ -12,6 +12,7 @@ export default function ssr_$id$(props) {
 
 export async function getServerSideProps(ctx) {
   await sleep(1);
+  await fetcher('resource');
   return {
     props: ctx,
   };

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,8 +7,8 @@ import { setEnvVars } from './setEnvVars';
 function hideBrowserEnv(): () => void {
   const tmpWindow = global.window;
   const tmpDocument = global.document;
-  const tmpfetch = global.fetch;
-  global.fetch = fetch;
+  const tmpFetch = global.fetch;
+  global.fetch = tmpFetch || fetch;
 
   // @ts-expect-error its okay
   delete global.window;
@@ -20,7 +20,7 @@ function hideBrowserEnv(): () => void {
   return () => {
     global.window = tmpWindow;
     global.document = tmpDocument;
-    global.fetch = tmpfetch;
+    global.fetch = tmpFetch;
 
     setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.CLIENT });
     setEnvVars({ runtimeEnv: RuntimeEnvironment.CLIENT });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,5 @@
+import fetch from 'cross-fetch';
+
 import { RuntimeEnvironment } from './constants';
 import setNextRuntimeConfig from './setNextRuntimeConfig';
 import { setEnvVars } from './setEnvVars';
@@ -5,6 +7,8 @@ import { setEnvVars } from './setEnvVars';
 function hideBrowserEnv(): () => void {
   const tmpWindow = global.window;
   const tmpDocument = global.document;
+  const tmpfetch = global.fetch;
+  global.fetch = fetch;
 
   // @ts-expect-error its okay
   delete global.window;
@@ -16,6 +20,8 @@ function hideBrowserEnv(): () => void {
   return () => {
     global.window = tmpWindow;
     global.document = tmpDocument;
+    global.fetch = tmpfetch;
+
     setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.CLIENT });
     setEnvVars({ runtimeEnv: RuntimeEnvironment.CLIENT });
   };


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hi,

I encountered an issue with `fetch` on the server side. Formally Next.js does a polyfill for fetch on the server environment, using
node-fetch.

This PR aims to void introducing coupling to the `next/next-server` package, which would be caused by importing 'next/dist/next-server/server/node-polyfill-fetch'.

Additionally, importing the `node-polyfill-fetch` obscures the clean up after simulating rendering on server side.

- Since `cross-fetch` is already installed in the project it can be used to polyfill.

- The polyfill with `cross-fetch` is only done if `global.fetch` is not defined, to avoid overriding user land definitions for `fetch`.

## What is the current behaviour?

In this `next` page:

```js
import Head from "next/head";
import styles from "../styles/Home.module.css";

export default function Home({ pokemon }) {
  return (
    <div>
      <Head>
        <title>{pokemon.name}</title>
      </Head>

      <main className={styles.main}>
        <h1 className={styles.title}>{pokemon.name}</h1>
      </main>

      <footer>
        <img src={pokemon.sprites.front_default} alt="a11y" />
      </footer>
    </div>
  );
}

export async function getServerSideProps() {
  const res = await fetch("https://pokeapi.co/api/v2/pokemon/1");
  const pokemon = await res.json();
  if (pokemon) {
    return { props: { pokemon } };
  } else {
    return { props: { pokemon: null } };
  }
}

```

Cannot be tested with `next-page-tester`, without stubbing or mocking `jest` on the node environment.

A simple test such as:

```js
import { screen } from "@testing-library/react";
import { getPage } from "next-page-tester";

describe("App", () => {
  it("renders without crashing", async () => {
    const { render } = await getPage({
      route: "/"
    });

    render();
    expect(screen.getByText("bulbasaur")).toBeInTheDocument();
  });
});

```

Won't be able to find `fetch` though it is only used on `getServerSideProps`. For better or worse, `next` polyfills `fetch` server side, and `next-page-tester` shouldn't disrupt that.

```bash
 FAIL  tests/index.test.js
  App
    ✕ renders without crashing (84 ms)

  ● App › renders without crashing

    ReferenceError: fetch is not defined

      27 |
      28 | export async function getServerSideProps() {
    > 29 |   const res = await fetch("https://pokeapi.co/api/v2/pokemon/1");
         |               ^
      30 |   const pokemon = await res.json();
      31 |   if (pokemon) {
      32 |     return { props: { pokemon } };

      at getServerSideProps (pages/index.js:29:15)
      at node_modules/next-page-tester/dist/fetchData/fetchPageData.js:93:71
      at Object.executeAsIfOnServer (node_modules/next-page-tester/dist/server.js:29:22)
      at Object.fetchPageData [as default] (node_modules/next-page-tester/dist/fetchData/fetchPageData.js:93:45)
      at Object.fetchRouteData (node_modules/next-page-tester/dist/fetchData/fetchRouteData.js:13:51)
      at Object.getPageInfo (node_modules/next-page-tester/dist/page/getPageInfo.js:20:22)
      at getPage (node_modules/next-page-tester/dist/getPage.js:64:38)
      at Object.<anonymous> (tests/index.test.js:6:24)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        1.215 s, estimated 2 s
```

## What is the new behaviour?

As explained above this PR attempts to polyfill on server side, only if `fetch` is not present.

```js
import fetch from 'cross-fetch';

// other imports

function hideBrowserEnv(): () => void {
  const tmpWindow = global.window;
  const tmpDocument = global.document;
  const tmpFetch = global.fetch; // <---
  global.fetch = tmpFetch || fetch; // <---

  // @ts-expect-error its okay
  delete global.window;
  // @ts-expect-error its okay
  delete global.document;
  setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.SERVER });
  setEnvVars({ runtimeEnv: RuntimeEnvironment.SERVER });

  return () => {
    global.window = tmpWindow;
    global.document = tmpDocument;
    global.fetch = tmpfetch; <-- clean up

    setNextRuntimeConfig({ runtimeEnv: RuntimeEnvironment.CLIENT });
    setEnvVars({ runtimeEnv: RuntimeEnvironment.CLIENT });
  };
}
```
...

## Does this PR introduce a breaking change?

No, because we'd use `cross-fetch` as polyfill only if the user has not specified any.

What changes might users need to make in their application due to this PR?

Nada.

## Other information:

As [polyfilled by `next`](https://github.com/vercel/next.js/blob/canary/packages/next/next-server/server/node-polyfill-fetch.js)

## Please check if the PR fulfills these requirements:

- [ x ] Tests for the changes have been added
- [ ] Docs have been added / updated
