### PR TITLE
fix(env): pass-through NODE_ENV to client

### DIFF
--- a/src/__tests__/environment-variables/__fixtures__/env-vars/pages/page.tsx
+++ b/src/__tests__/environment-variables/__fixtures__/env-vars/pages/page.tsx
@@ -7,6 +7,7 @@ export default function EnvironmentVariablesPage({
   envVarsMock: { [key: string]: unknown };
 }) {
   const {
+    NODE_ENV,
     FROM_RUNTIME,
     NEXT_PUBLIC_FROM_RUNTIME,
     FROM_CONFIG,
@@ -20,6 +21,7 @@ export default function EnvironmentVariablesPage({
   } = process.env;
 
   const envVars = {
+    NODE_ENV,
     FROM_RUNTIME,
     NEXT_PUBLIC_FROM_RUNTIME,
     FROM_CONFIG,

--- a/src/__tests__/environment-variables/environment-variables.test.tsx
+++ b/src/__tests__/environment-variables/environment-variables.test.tsx
@@ -24,6 +24,8 @@ describe('Environment variables', () => {
       const { container: expected } = renderWithinNextRoot(
         <Page
           envVarsMock={{
+            NODE_ENV: 'test',
+
             FROM_RUNTIME: 'FROM_RUNTIME',
             NEXT_PUBLIC_FROM_RUNTIME: 'NEXT_PUBLIC_FROM_RUNTIME',
 
@@ -54,6 +56,7 @@ describe('Environment variables', () => {
         const { container: expected } = renderWithinNextRoot(
           <EnvVarsCleanupPage
             envVarsMock={{
+              NODE_ENV: 'test',
               FROM_RUNTIME: 'FROM_RUNTIME',
               NEXT_PUBLIC_FROM_RUNTIME: 'NEXT_PUBLIC_FROM_RUNTIME',
               NAME_CLASH_RUNTIME_VS_CONFIG: 'FROM_RUNTIME',
@@ -78,6 +81,7 @@ describe('Environment variables', () => {
       const { container: expected } = renderWithinNextRoot(
         <Page
           envVarsMock={{
+            NODE_ENV: 'test',
             NEXT_PUBLIC_FROM_RUNTIME: 'NEXT_PUBLIC_FROM_RUNTIME',
             FROM_CONFIG: 'FROM_CONFIG',
             NEXT_PUBLIC_FROM_CONFIG: 'NEXT_PUBLIC_FROM_CONFIG',
@@ -101,6 +105,7 @@ describe('Environment variables', () => {
         const { container: expected } = renderWithinNextRoot(
           <EnvVarsCleanupPage
             envVarsMock={{
+              NODE_ENV: 'test',
               NEXT_PUBLIC_FROM_RUNTIME: 'NEXT_PUBLIC_FROM_RUNTIME',
             }}
           />

--- a/src/setEnvVars.ts
+++ b/src/setEnvVars.ts
@@ -11,14 +11,21 @@ type EnvVars = Record<string, string | undefined>;
 
 type ScopedEnvVars = Record<RuntimeEnvironment, EnvVars>;
 
+const CLIENT_PASSTHROUGH_VARS = new Set(['NODE_ENV']);
+
 function scopeEnvVarsByEnvironment(vars: EnvVars): ScopedEnvVars {
   const serverVars = { ...vars };
   const clientVars = { ...vars };
   for (const varName in vars) {
+    if (CLIENT_PASSTHROUGH_VARS.has(varName)) {
+      continue;
+    }
+
     if (!varName.startsWith('NEXT_PUBLIC_')) {
       delete clientVars[varName];
     }
   }
+
   return { [SERVER]: serverVars, [CLIENT]: clientVars };
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Pass through `NODE_ENV` to the client

## What is the current behaviour?

`NODE_ENV` is not available in `client` context which is:
- not in-line with `Next.JS`
- makes it hard to have conditional logic based on `process.env.NODE_ENV === 'test'`

## What is the new behaviour?

`NODE_ENV` is passed through to the client context

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
