### PR TITLE
feat: implement routing locales

### DIFF
--- a/src/__tests__/i18n/__fixtures__/next.config.js
+++ b/src/__tests__/i18n/__fixtures__/next.config.js
@@ -1,0 +1,28 @@
+// next.config.js
+module.exports = {
+  i18n: {
+    // These are all the locales you want to support in
+    // your application
+    locales: ['en-US', 'fr', 'nl-NL'],
+    // This is the default locale you want to be used when visiting
+    // a non-locale prefixed path e.g. `/hello`
+    defaultLocale: 'en-US',
+    // This is a list of locale domains and the default locale they
+    // should handle (these are only required when setting up domain routing)
+    // Note: subdomains must be included in the domain value to be matched e.g. "fr.example.com".
+    domains: [
+      {
+        domain: 'example.com',
+        defaultLocale: 'en-US',
+      },
+      {
+        domain: 'example.nl',
+        defaultLocale: 'nl-NL',
+      },
+      {
+        domain: 'example.fr',
+        defaultLocale: 'fr',
+      },
+    ],
+  },
+};

--- a/src/__tests__/i18n/__fixtures__/pages/another.tsx
+++ b/src/__tests__/i18n/__fixtures__/pages/another.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+
+export default function Another() {
+  const { locale, locales, defaultLocale, push } = useRouter();
+  return (
+    <>
+      <h1>Another page</h1>
+      <span>{JSON.stringify({ locale, locales, defaultLocale })}</span>
+      <button
+        onClick={() => {
+          push('/', '/', { locale: 'nl-NL' });
+        }}
+      >
+        to /nl-NL/index
+      </button>
+    </>
+  );
+}

--- a/src/__tests__/i18n/__fixtures__/pages/index.tsx
+++ b/src/__tests__/i18n/__fixtures__/pages/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
+
+export default function Index() {
+  const { locale, locales, defaultLocale } = useRouter();
+  return (
+    <>
+      <h1>Index page</h1>
+      <span>{JSON.stringify({ locale, locales, defaultLocale })}</span>
+      <Link href="/fr/another">
+        <a>To /fr/another</a>
+      </Link>
+    </>
+  );
+}

--- a/src/__tests__/i18n/i18n.test.ts
+++ b/src/__tests__/i18n/i18n.test.ts
@@ -1,0 +1,50 @@
+import { getPage } from '../../../src';
+import path from 'path';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+describe('i18n', () => {
+  it('should corretly handle locales', async () => {
+    const { render } = await getPage({
+      route: '/',
+      nextRoot: path.join(__dirname, '__fixtures__'),
+    });
+    render();
+
+    expect(
+      screen.getByText(
+        JSON.stringify({
+          locale: 'en-US',
+          locales: ['en-US', 'fr', 'nl-NL'],
+          defaultLocale: 'en-US',
+        })
+      )
+    ).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('To /fr/another'));
+
+    await screen.findByText('Another page');
+    expect(
+      screen.getByText(
+        JSON.stringify({
+          locale: 'fr',
+          locales: ['en-US', 'fr', 'nl-NL'],
+          defaultLocale: 'en-US',
+        })
+      )
+    ).toBeInTheDocument();
+
+    userEvent.click(screen.getByRole('button', { name: 'to /nl-NL/index' }));
+    await screen.findByText('Index page');
+
+    expect(
+      screen.getByText(
+        JSON.stringify({
+          locale: 'nl-NL',
+          locales: ['en-US', 'fr', 'nl-NL'],
+          defaultLocale: 'en-US',
+        })
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/router/makeRouterMock.ts
+++ b/src/router/makeRouterMock.ts
@@ -1,5 +1,5 @@
 import { NextRouter } from 'next/router';
-import { removeFileExtension, parseRouteWithLocales } from '../utils';
+import { removeFileExtension, parseLocaleRoute } from '../utils';
 import type { ExtendedOptions, PageObject } from '../commonTypes';
 import { getNextConfig } from '../nextConfig';
 
@@ -59,9 +59,9 @@ export default function makeRouterMock({
 }): NextRouter {
   const { i18n } = getNextConfig();
   const {
-    url: { pathname, search, hash },
+    urlObject: { pathname, search, hash },
     detectedLocale,
-  } = parseRouteWithLocales({ route, locales: i18n?.locales });
+  } = parseLocaleRoute({ route, locales: i18n?.locales });
 
   const router: NextRouter = {
     ...makeDefaultRouterMock({ pushHandler }),

--- a/src/router/makeRouterMock.ts
+++ b/src/router/makeRouterMock.ts
@@ -1,13 +1,16 @@
 import { NextRouter } from 'next/router';
-import { removeFileExtension, parseRoute } from '../utils';
+import { removeFileExtension, parseRouteWithLocales } from '../utils';
 import type { ExtendedOptions, PageObject } from '../commonTypes';
+import { getNextConfig } from '../nextConfig';
 
 type NextPushArgs = Parameters<NextRouter['push']>;
+
+export type TransitionOptions = NextPushArgs[2];
 
 export type PushHandler = (
   url: NextPushArgs[0],
   as: NextPushArgs[1],
-  options: NextPushArgs[2]
+  options: TransitionOptions
 ) => void;
 
 // https://github.com/vercel/next.js/issues/7479#issuecomment-659859682
@@ -54,14 +57,22 @@ export default function makeRouterMock({
   pageObject: PageObject;
   pushHandler?: PushHandler;
 }): NextRouter {
-  const { pathname, search, hash } = parseRoute({ route });
-  const router = {
+  const { i18n } = getNextConfig();
+  const {
+    url: { pathname, search, hash },
+    detectedLocale,
+  } = parseRouteWithLocales({ route, locales: i18n?.locales });
+
+  const router: NextRouter = {
     ...makeDefaultRouterMock({ pushHandler }),
     asPath: pathname + search + hash, // Includes querystring and anchor
     pathname: removeFileExtension({ path: pagePath }), // Page component path without extension
     query: { ...params, ...query }, // Route params + parsed querystring
     route: removeFileExtension({ path: pagePath }), // Page component path without extension
     basePath: '',
+    locales: i18n?.locales,
+    defaultLocale: i18n?.defaultLocale,
+    locale: detectedLocale || i18n?.defaultLocale,
   };
 
   return routerEnhancer(router);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,6 +14,7 @@ export function parseRoute({ route }: { route: string }) {
   return parseLocaleRoute({ route, locales: i18n?.locales }).urlObject;
 }
 
+// @TODO: Consider merging this with parseRoute
 export function parseLocaleRoute({
   route,
   locales,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,23 +11,20 @@ import { normalizeLocalePath } from 'next/dist/next-server/lib/i18n/normalize-lo
 
 export function parseRoute({ route }: { route: string }) {
   const { i18n } = getNextConfig();
-  return parseRouteWithLocales({ route, locales: i18n?.locales }).url;
+  return parseLocaleRoute({ route, locales: i18n?.locales }).urlObject;
 }
 
-export function parseRouteWithLocales({
+export function parseLocaleRoute({
   route,
   locales,
 }: {
   route: string;
   locales: string[] | undefined;
 }) {
-  const url = new URL(`http://test.com${route}`);
-  const { pathname: pathnameWithLocale } = url;
-  const { pathname, detectedLocale } = normalizeLocalePath(
-    pathnameWithLocale,
-    locales
-  );
-  url.pathname = pathname;
+  const urlObject = new URL(`http://test.com${route}`);
+  const { pathname: localePath } = urlObject;
+  const { pathname, detectedLocale } = normalizeLocalePath(localePath, locales);
+  urlObject.pathname = pathname;
 
   /*
    * Next.js redirects by default routes with trailing slash to the counterpart without trailing slash
@@ -35,10 +32,10 @@ export function parseRouteWithLocales({
    * https://nextjs.org/docs/api-reference/next.config.js/trailing-slash
    */
   if (pathname.endsWith('/') && pathname !== '/') {
-    url.pathname = pathname.slice(0, -1);
+    urlObject.pathname = pathname.slice(0, -1);
   }
 
-  return { url, detectedLocale };
+  return { urlObject, detectedLocale };
 }
 
 export function parseQueryString({


### PR DESCRIPTION
## What kind of change does this PR introduce?

Populate `i18n` (locale) field in the router.

Fixes https://github.com/toomuchdesign/next-page-tester/issues/188

## What is the current behaviour?

`i18n` field are not populated.

## What is the new behaviour?

`i18n` field are populated.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [ ] Docs have been added / updated
