### PR TITLE
fix: don't throw if config-utils doesn't exist

### DIFF
--- a/src/nextConfig.ts
+++ b/src/nextConfig.ts
@@ -10,12 +10,14 @@ import { InternalError } from './_error';
  *
  * @NOTE: This is a very flaky temporary workaround
  */
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const configUtils = require('next/dist/next-server/server/config-utils');
-/* istanbul ignore next */
-if (configUtils && configUtils.loadWebpackHook) {
-  configUtils.loadWebpackHook = () => {};
-}
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const configUtils = require('next/dist/next-server/server/config-utils');
+  /* istanbul ignore next */
+  if (configUtils && configUtils.loadWebpackHook) {
+    configUtils.loadWebpackHook = () => {};
+  }
+} catch (e) {} // eslint-disable-line no-empty
 
 let nextConfig: NextConfig;
 export async function loadNextConfig({ nextRoot }: { nextRoot: string }) {

--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -52,10 +52,10 @@ export function getPageFileIfExists<FileType>({
   try {
     return loadFile({ absolutePath });
   } catch (e) {
-    const internalEror = new InternalError(
+    const internalError = new InternalError(
       `Failed to load "${pagePath}" file due to ${e.name}: ${e.message}`
     );
-    internalEror.stack = e.stack;
-    throw internalEror;
+    internalError.stack = e.stack;
+    throw internalError;
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behaviour?

#200

## What is the new behaviour?

Patch `config-utils` only if require succeeds.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
