### PR TITLE
feat: Add custom wrapper for _app

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ React element of the application.
 
 ## Options
 
-| Property                       | Description                                                                        | type                              | Default         |
-| ------------------------------ | ---------------------------------------------------------------------------------- | --------------------------------- | --------------- |
-| **route** (mandatory)          | Next route (must start with `/`)                                                   | `string`                          | -               |
-| **req**                        | Enhance default mocked [request object][req-docs]                                  | `req => req`                      | -               |
-| **res**                        | Enhance default mocked [response object][res-docs]                                 | `res => res`                      | -               |
-| **router**                     | Enhance default mocked [Next router object][next-docs-router]                      | `router => router`                | -               |
-| **useApp**                     | Render [custom App component][next-docs-custom-app]                                | `boolean`                         | `true`          |
-| **useDocument** (experimental) | Render [Document component][next-docs-custom-document]                             | `boolean`                         | `false`         |
-| **nextRoot**                   | Absolute path to Next.js root folder                                               | `string`                          | _auto detected_ |
-| **dotenvFile**                 | Relative path to a `.env` file holding [environment variables][next-docs-env-vars] | `string`                          | -               |
-| **wrapper**                    | Map of render functions. Useful to decorate component tree with mocked providers.  | `{ Page?: NextPage => NextPage }` | -               |
-| **sharedModules**              | List of modules that should preserve identity between client and server context.   | `string[]`                        | []              |
+| Property                       | Description                                                                        | type                                                        | Default         |
+| ------------------------------ | ---------------------------------------------------------------------------------- | ----------------------------------------------------------- | --------------- |
+| **route** (mandatory)          | Next route (must start with `/`)                                                   | `string`                                                    | -               |
+| **req**                        | Enhance default mocked [request object][req-docs]                                  | `req => req`                                                | -               |
+| **res**                        | Enhance default mocked [response object][res-docs]                                 | `res => res`                                                | -               |
+| **router**                     | Enhance default mocked [Next router object][next-docs-router]                      | `router => router`                                          | -               |
+| **useApp**                     | Render [custom App component][next-docs-custom-app]                                | `boolean`                                                   | `true`          |
+| **useDocument** (experimental) | Render [Document component][next-docs-custom-document]                             | `boolean`                                                   | `false`         |
+| **nextRoot**                   | Absolute path to Next.js root folder                                               | `string`                                                    | _auto detected_ |
+| **dotenvFile**                 | Relative path to a `.env` file holding [environment variables][next-docs-env-vars] | `string`                                                    | -               |
+| **wrapper**                    | Map of render functions. Useful to decorate component tree with mocked providers.  | `{ Page?: NextPage => NextPage; App?: NextApp => NextApp }` | -               |
+| **sharedModules**              | List of modules that should preserve identity between client and server context.   | `string[]`                                                  | []              |
 
 ## Setting up your dev environment
 

--- a/src/__tests__/wrapper/__fixtures__/App/pages/_app.tsx
+++ b/src/__tests__/wrapper/__fixtures__/App/pages/_app.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function CustomApp({
+  Component,
+  pageProps,
+}: {
+  Component: React.ElementType;
+  pageProps?: Record<string, unknown>;
+}) {
+  return <Component {...pageProps} />;
+}

--- a/src/__tests__/wrapper/__fixtures__/App/pages/a.tsx
+++ b/src/__tests__/wrapper/__fixtures__/App/pages/a.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { MockedProvider } from '../../MockedProvider';
+
+export default function PageA() {
+  return (
+    <MockedProvider.Consumer>
+      {({ source }) => <p>Source: {source}</p>}
+    </MockedProvider.Consumer>
+  );
+}

--- a/src/__tests__/wrapper/wrapper.test.tsx
+++ b/src/__tests__/wrapper/wrapper.test.tsx
@@ -28,4 +28,25 @@ describe('wrapper', () => {
 
     expect(screen.getByText(`Source: ${source}`)).toBeInTheDocument();
   });
+
+  test('accepts App enhancer', async () => {
+    const source = 'App wrapper';
+    const { render } = await getPage({
+      nextRoot: path.join(__dirname, '__fixtures__', 'App'),
+      route: '/a',
+      wrapper: {
+        App: (App) => (appProps) => {
+          return (
+            <MockedProvider.Provider value={{ source }}>
+              <App {...appProps} />
+            </MockedProvider.Provider>
+          );
+        },
+      },
+    });
+
+    render();
+
+    expect(screen.queryByText(`Source: ${source}`)).toBeInTheDocument();
+  });
 });

--- a/src/_app/render.tsx
+++ b/src/_app/render.tsx
@@ -42,8 +42,15 @@ export function renderEnhancedApp({
   options: ExtendedOptions;
 }) {
   let UserEnhancedPage = Page;
+  let UserEnhancedApp = App;
+
+  if (wrapper.App) {
+    UserEnhancedApp = wrapper.App(App);
+  }
+
   if (wrapper.Page) {
     UserEnhancedPage = wrapper.Page(Page);
   }
-  return <App Component={UserEnhancedPage} pageProps={pageProps} />;
+
+  return <UserEnhancedApp Component={UserEnhancedPage} pageProps={pageProps} />;
 }

--- a/src/commonTypes.ts
+++ b/src/commonTypes.ts
@@ -30,6 +30,7 @@ export type Options = {
   useDocument?: boolean;
   dotenvFile?: string;
   wrapper?: {
+    App?: Enhancer<NextApp>;
     Page?: Enhancer<NextPage>;
   };
 };


### PR DESCRIPTION
Closes #210

## What kind of change does this PR introduce?

Adds a `wrapper.App` option, similar to the existing `wrapper.Page`.

## What is the current behaviour?

Only a `Page` wrapper is available, which is certainly useful, but insufficient for certain behaviors.

## What is the new behaviour?

#210

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
