### PR TITLE
feat: Add locale fields to data fetching contexts

### DIFF
--- a/src/__tests__/i18n/__fixtures__/pages/ssg.js
+++ b/src/__tests__/i18n/__fixtures__/pages/ssg.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function SSG({ locale, locales, defaultLocale }) {
+  return <span>{JSON.stringify({ locale, locales, defaultLocale })}</span>;
+}
+
+export async function getStaticProps(ctx) {
+  return {
+    props: ctx,
+  };
+}

--- a/src/__tests__/i18n/__fixtures__/pages/ssr.js
+++ b/src/__tests__/i18n/__fixtures__/pages/ssr.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function SSR({ locale, locales, defaultLocale }) {
+  return <span>{JSON.stringify({ locale, locales, defaultLocale })}</span>;
+}
+
+export async function getServerSideProps(ctx) {
+  return {
+    props: ctx,
+  };
+}

--- a/src/__tests__/i18n/i18n.test.ts
+++ b/src/__tests__/i18n/i18n.test.ts
@@ -48,3 +48,30 @@ describe('i18n', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe.each([
+  ['getStaticProps()', 'ssg'],
+  ['getServerSideProps()', 'ssr'],
+])('%s', (_fetcher, pageName) => {
+  it.each([
+    [`/${pageName}`, 'en-US'],
+    [`/fr/${pageName}`, 'fr'],
+    [`/nl-NL/${pageName}`, 'nl-NL'],
+  ])('receives locale context of %s', async (route, locale) => {
+    const { render } = await getPage({
+      route,
+      nextRoot: path.join(__dirname, '__fixtures__'),
+    });
+    render();
+
+    expect(
+      screen.queryByText(
+        JSON.stringify({
+          locale,
+          locales: ['en-US', 'fr', 'nl-NL'],
+          defaultLocale: 'en-US',
+        })
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/fetchData/fetchPageData.ts
+++ b/src/fetchData/fetchPageData.ts
@@ -151,6 +151,7 @@ export default async function fetchPageData({
     if (serverPageFile.getStaticProps) {
       const { getStaticProps } = serverPageFile;
       const ctx: GetStaticPropsContext<typeof params> = makeStaticPropsContext({
+        options,
         pageObject,
       });
       // @TODO introduce `getStaticPaths` logic

--- a/src/fetchData/makeContextObject.ts
+++ b/src/fetchData/makeContextObject.ts
@@ -6,6 +6,7 @@ import type {
 } from 'next';
 import { parse } from 'cookie';
 import makeHttpObjects from './makeHttpObjects';
+import { makeRouterMock } from '../router';
 import type {
   ExtendedOptions,
   FoundPageObject,
@@ -46,17 +47,22 @@ export function makeGetInitialPropsContext({
 
 export function makeGetServerSidePropsContext({
   pageObject,
-  options: { req: reqMocker, res: resMocker, previousRoute },
+  options,
 }: {
   pageObject: FoundPageObject;
   options: ExtendedOptions;
 }): GetServerSidePropsContext<typeof pageObject.params> {
+  const { req: reqMocker, res: resMocker, previousRoute } = options;
   const { params, query, resolvedUrl } = pageObject;
   const { req, res } = makeHttpObjects({
     pageObject,
     reqMocker,
     resMocker,
     refererRoute: previousRoute,
+  });
+  const { locale, locales, defaultLocale } = makeRouterMock({
+    options,
+    pageObject,
   });
 
   // parsed "cookies" are only available in "getServerSideProps" data fetching method
@@ -73,19 +79,31 @@ export function makeGetServerSidePropsContext({
     resolvedUrl,
     req,
     res,
+    locale,
+    locales,
+    defaultLocale,
   };
 }
 
 export function makeStaticPropsContext({
   pageObject,
+  options,
 }: {
   pageObject: FoundPageObject;
+  options: ExtendedOptions;
 }): GetStaticPropsContext<typeof pageObject.params> {
   const { params } = pageObject;
+  const { locale, locales, defaultLocale } = makeRouterMock({
+    options,
+    pageObject,
+  });
 
   // @TODO complete ctx object
   // https://nextjs.org/docs/basic-features/data-fetching#getstaticprops-static-generation
   return {
     params: { ...params },
+    locale,
+    locales,
+    defaultLocale,
   };
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Increased fidelity to Next.js behaviors during page data fetching, adding the missing locale properties to the context object passed to `getServerSideProps()` and `getStaticProps()`.

## What is the current behaviour?

An incomplete context object is passed, lacking the locale-related properties.

## What is the new behaviour?

The properties `locale`, `locales`, and `defaultLocale` are now available on SSR/SSG context objects, matching the behavior of Next.js.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
