### PR TITLE
fix: change moduleName -> mockModuleName

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,11 +115,11 @@ const predefinedSharedModules = [
 ];
 
 function preserveJestSharedModulesIdentity(modules: string[]): void {
-  for (const moduleName of modules) {
+  for (const mockModuleName of modules) {
     // @NOTE for some reason Jest needs us to pre-import the modules
     // we want to require with jest.requireActual
-    require(moduleName);
-    jest.mock(moduleName, () => jest.requireActual(moduleName));
+    require(mockModuleName);
+    jest.mock(mockModuleName, () => jest.requireActual(mockModuleName));
   }
 }
 
@@ -143,7 +143,7 @@ export function executeWithFreshModules<T>(
     // @ts-expect-error result is surely defined here
     return result;
   }
-  // @NOTE this branch will never be execute by Jest
+  // @NOTE this branch will never be executed by Jest
   else {
     return stealthyRequire(
       require.cache,


### PR DESCRIPTION
This fixes the following error, i.e. #216, which should still be open:
```
the module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.     Invalid variable access: moduleName
```

This fixes #216 for me using TypeScript using @latest for all libraries (i.e. next-11.0.2) in a TypeScript environment.

There would seem to be something "lost in translation" between the `.ts -> .js with types.d.ts` conversion for the npm package.

This solution comes from a monkey-patch, but it's a simple refactor of one variable name on 4 lines, so it should be good to go.

![image](https://user-images.githubusercontent.com/761231/126847848-f8853c72-30d3-4560-8922-40307ca67adc.png)

## What kind of change does this PR introduce?

Bug fix for breaking bug on current npm package version `next-page-tester@0.27.0` installed with `npm install --save-dev next-page-tester --force`.

## What is the current behaviour?

Same as closed #216. Given the complexity of this project, it's difficult to provide a minimal repo, but here you go.

Repository: @DoctorDerek/calendar-appointments
Branch: `next-page-test-bug`
Link: https://github.com/DoctorDerek/calendar-appointments/tree/next-page-test-bug

Repo instructions
- Clone the repo's `next-page-test-bug` branch
- `npm install --force`
- `npm run test`
- View error
- ...
- Profit

Note that --force is required because of the peerDependency inaccuracy (^10...) in `next-page-test` ... I didn't want to fix that in the same PR because it is potentially confusing. There shouldn't have been any breaking changes with Next 11, that I could tell, though.

Monkey patch instructions:
```js
// Change lines 96-103 in /node-modules/next-page-test/dist/utils.js to:
function preserveJestSharedModulesIdentity(modules) {
    for (const mockModuleName of modules) {
        // @NOTE for some reason Jest needs us to pre-import the modules
        // we want to require with jest.requireActual
        require(mockModuleName);
        jest.mock(mockModuleName, () => jest.requireActual(mockModuleName));
    }
}
```

## What is the new behaviour?

It works.

## Does this PR introduce a breaking change?

No.

## Other information:

## Please check if the PR fulfills these requirements:

- [ N/A ] Tests for the changes have been added
- [ N/A ] Docs have been added / updated
