### PR TITLE
feat: include caught jest error details on getPageFile error (#269)

### DIFF
--- a/src/page/getPageFile.ts
+++ b/src/page/getPageFile.ts
@@ -52,17 +52,14 @@ export function getPageFileIfExists<FileType>({
   try {
     return loadFile({ absolutePath });
   } catch (e: unknown) {
+    /* istanbul ignore else */
     if (e instanceof Error) {
       const internalError = new InternalError(
         `Failed to load "${pagePath}" file due to ${e.name}: ${e.message}`
       );
       internalError.stack = e.stack;
       throw internalError;
-    } /* istanbul ignore next */ else if (
-      e &&
-      typeof e === 'object' &&
-      'message' in e
-    ) {
+    } else if (e && typeof e === 'object' && 'message' in e) {
       // Jest can throw errors as pure objects, to provide better information
       // we need to include the original message in the thrown error.
       // See https://github.com/toomuchdesign/next-page-tester/issues/269


### PR DESCRIPTION
## What kind of change does this PR introduce?

An adjustment to the logic of `getPageFile`'s `catch` behaviour.

## What is the current behaviour?

If there's an error with Jest, eg. loading mock files required in a Next.js page, the library simply shows the following error message:

```sh
[next-page-tester] Failed to load "/_app"
```

The root cause is that Jest does not throw Errors but simple error objects (`object` instead `typeof Error`)

## What is the new behaviour?

We also show the message of the caught object error to provide details for the developer on how to fix the issue as the issue is not related to next-page-tester:

```sh
[next-page-tester] Failed to load "/_app"

Configuration error:
    
Could not locate module ../styles/globals.css mapped as:
/Users/janbiasi/Documents/github/next-page-tester-issue-269/__mocks__/styleMock.js.
    
Please check your configuration for these entries:
{
  "moduleNameMapper": {
    "/^.+\.(css|sass|scss)$/": "/Users/janbiasi/Documents/github/next-page-tester-issue-269/__mocks__/styleMock.js"
  },
  "resolver": undefined
}
```

_Note: The object only provides the message, the original stack can't be retrieved._

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated

Neither one:
* I noticed that there are no unit-tests for the `getPagePath` and I'm not quite sure if and how we should test this behaviour that Jest fails to process the corresponding imports.
* This is an internal optimisation only
